### PR TITLE
[공통] Coordinator 리팩토링

### DIFF
--- a/Routinus/Routinus.xcodeproj/project.pbxproj
+++ b/Routinus/Routinus.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		E9797CBF27310E2A00A14A0F /* ManageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9797CBE27310E2A00A14A0F /* ManageCoordinator.swift */; };
 		E9797CC127310E3300A14A0F /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9797CC027310E3300A14A0F /* MyPageCoordinator.swift */; };
 		E9797CC32731258A00A14A0F /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9797CC22731258A00A14A0F /* HomeViewModel.swift */; };
+		E99474502736D54C0054A631 /* DetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E994744F2736D54C0054A631 /* DetailCoordinator.swift */; };
 		E9B1298227336EE50072D254 /* TodayRoutine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B1298127336EE50072D254 /* TodayRoutine.swift */; };
 /* End PBXBuildFile section */
 
@@ -118,6 +119,7 @@
 		E9797CBE27310E2A00A14A0F /* ManageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageCoordinator.swift; sourceTree = "<group>"; };
 		E9797CC027310E3300A14A0F /* MyPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinator.swift; sourceTree = "<group>"; };
 		E9797CC22731258A00A14A0F /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		E994744F2736D54C0054A631 /* DetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCoordinator.swift; sourceTree = "<group>"; };
 		E9B1298127336EE50072D254 /* TodayRoutine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayRoutine.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -317,6 +319,7 @@
 				E9797CBC27310E1900A14A0F /* HomeCoordinator.swift */,
 				E9797CBE27310E2A00A14A0F /* ManageCoordinator.swift */,
 				E9797CC027310E3300A14A0F /* MyPageCoordinator.swift */,
+				E994744F2736D54C0054A631 /* DetailCoordinator.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -585,6 +588,7 @@
 				E9797CB3273107BE00A14A0F /* CreateController.swift in Sources */,
 				E9797CAD2731074B00A14A0F /* ManageViewController.swift in Sources */,
 				E9797CA22730FFAD00A14A0F /* TabBarCoordinator.swift in Sources */,
+				E99474502736D54C0054A631 /* DetailCoordinator.swift in Sources */,
 				E9797CBB27310E1000A14A0F /* ChallengeCoordinator.swift in Sources */,
 				E9797CB92731094900A14A0F /* AuthViewController.swift in Sources */,
 				E9797CB1273107A200A14A0F /* DetailViewController.swift in Sources */,

--- a/Routinus/Routinus.xcodeproj/project.pbxproj
+++ b/Routinus/Routinus.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		E9797CC127310E3300A14A0F /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9797CC027310E3300A14A0F /* MyPageCoordinator.swift */; };
 		E9797CC32731258A00A14A0F /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9797CC22731258A00A14A0F /* HomeViewModel.swift */; };
 		E99474502736D54C0054A631 /* DetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E994744F2736D54C0054A631 /* DetailCoordinator.swift */; };
+		E99474522736F4B30054A631 /* AuthCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99474512736F4B30054A631 /* AuthCoordinator.swift */; };
 		E9B1298227336EE50072D254 /* TodayRoutine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B1298127336EE50072D254 /* TodayRoutine.swift */; };
 /* End PBXBuildFile section */
 
@@ -120,6 +121,7 @@
 		E9797CC027310E3300A14A0F /* MyPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinator.swift; sourceTree = "<group>"; };
 		E9797CC22731258A00A14A0F /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		E994744F2736D54C0054A631 /* DetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCoordinator.swift; sourceTree = "<group>"; };
+		E99474512736F4B30054A631 /* AuthCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCoordinator.swift; sourceTree = "<group>"; };
 		E9B1298127336EE50072D254 /* TodayRoutine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayRoutine.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -320,6 +322,7 @@
 				E9797CBE27310E2A00A14A0F /* ManageCoordinator.swift */,
 				E9797CC027310E3300A14A0F /* MyPageCoordinator.swift */,
 				E994744F2736D54C0054A631 /* DetailCoordinator.swift */,
+				E99474512736F4B30054A631 /* AuthCoordinator.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -577,6 +580,7 @@
 				E975390627325538004358C5 /* AchievementInfo.swift in Sources */,
 				E9797CBD27310E1900A14A0F /* HomeCoordinator.swift in Sources */,
 				0DD1632D2733729800DC5970 /* CalendarDelegate.swift in Sources */,
+				E99474522736F4B30054A631 /* AuthCoordinator.swift in Sources */,
 				44AAA3242733819B002E16C4 /* Date+Extensions.swift in Sources */,
 				44AAA2B9272FDF8B002E16C4 /* HomeViewController.swift in Sources */,
 				E9797CC127310E3300A14A0F /* MyPageCoordinator.swift in Sources */,

--- a/Routinus/Routinus/Application/Coordinator/AppCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/AppCoordinator.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 class AppCoordinator: Coordinator {
+    var parentCoordinator: Coordinator?
     var childCoordinator: [Coordinator] = []
     var navigationController: UINavigationController
 

--- a/Routinus/Routinus/Application/Coordinator/AuthCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/AuthCoordinator.swift
@@ -1,0 +1,25 @@
+//
+//  AuthCoordinator.swift
+//  Routinus
+//
+//  Created by 박상우 on 2021/11/07.
+//
+
+import UIKit
+
+class AuthCoordinator: Coordinator {
+    var parentCoordinator: Coordinator?
+    var childCoordinator: [Coordinator] = []
+    var navigationController: UINavigationController
+    let challengeID: String
+
+    init(navigationController: UINavigationController, challengeID: String) {
+        self.navigationController = navigationController
+        self.challengeID = challengeID
+    }
+
+    func start() {
+        let authViewController = AuthViewController()
+        self.navigationController.pushViewController(authViewController, animated: false)
+    }
+}

--- a/Routinus/Routinus/Application/Coordinator/ChallengeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/ChallengeCoordinator.swift
@@ -30,11 +30,21 @@ class ChallengeCoordinator: Coordinator {
         case .detail:
             resetToRoot()
             if let challengeID = challengeID {
-                let detailCoordinator = DetailCoordinator(navigationController: navigationController, challengeID: challengeID)
+                let detailCoordinator = DetailCoordinator(
+                    navigationController: navigationController,
+                    challengeID: challengeID
+                )
                 detailCoordinator.start()
             }
         case .auth:
             resetToRoot()
+            if let challengeID = challengeID {
+                let authCoordinator = AuthCoordinator(
+                    navigationController: navigationController,
+                    challengeID: challengeID
+                )
+                authCoordinator.start()
+            }
         }
     }
 

--- a/Routinus/Routinus/Application/Coordinator/ChallengeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/ChallengeCoordinator.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 class ChallengeCoordinator: Coordinator {
+    var parentCoordinator: Coordinator?
     var childCoordinator: [Coordinator] = []
     var navigationController: UINavigationController
 

--- a/Routinus/Routinus/Application/Coordinator/ChallengeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/ChallengeCoordinator.swift
@@ -20,4 +20,25 @@ class ChallengeCoordinator: Coordinator {
         let challengeViewController = ChallengeViewController()
         self.navigationController.pushViewController(challengeViewController, animated: false)
     }
+
+    func moveTo(type: ChallegeType, challengeID: String? = nil) {
+        switch type {
+        case .main:
+            resetToRoot()
+        case .search:
+            resetToRoot()
+        case .detail:
+            resetToRoot()
+            if let challengeID = challengeID {
+                let detailCoordinator = DetailCoordinator(navigationController: navigationController, challengeID: challengeID)
+                detailCoordinator.start()
+            }
+        case .auth:
+            resetToRoot()
+        }
+    }
+
+    private func resetToRoot() {
+        self.navigationController.popToRootViewController(animated: false)
+    }
 }

--- a/Routinus/Routinus/Application/Coordinator/Coordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/Coordinator.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 protocol Coordinator: AnyObject {
+    var parentCoordinator: Coordinator?
     var childCoordinator: [Coordinator] { get set }
     var navigationController: UINavigationController { get }
 

--- a/Routinus/Routinus/Application/Coordinator/Coordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/Coordinator.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol Coordinator: AnyObject {
-    var parentCoordinator: Coordinator?
+    var parentCoordinator: Coordinator? { get set }
     var childCoordinator: [Coordinator] { get set }
     var navigationController: UINavigationController { get }
 

--- a/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
@@ -11,9 +11,11 @@ class DetailCoordinator: Coordinator {
     var parentCoordinator: Coordinator?
     var childCoordinator: [Coordinator] = []
     var navigationController: UINavigationController
+    let challengeID: String
 
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController, challengeID: String) {
         self.navigationController = navigationController
+        self.challengeID = challengeID
     }
 
     func start() {

--- a/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
@@ -1,0 +1,23 @@
+//
+//  DetailCoordinator.swift
+//  Routinus
+//
+//  Created by 박상우 on 2021/11/07.
+//
+
+import UIKit
+
+class DetailCoordinator: Coordinator {
+    var parentCoordinator: Coordinator?
+    var childCoordinator: [Coordinator] = []
+    var navigationController: UINavigationController
+
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+
+    func start() {
+        let detailViewController = DetailViewController()
+        self.navigationController.pushViewController(detailViewController, animated: false)
+    }
+}

--- a/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
@@ -36,6 +36,14 @@ class HomeCoordinator: Coordinator {
                 tapBarCoordinator.moveToChallegeType(type: .detail, challengeID: challengeID)
             }
             .store(in: &cancellables)
+        
+        homeViewModel.showChallengeAuthSignal
+            .sink { [weak self] challengeID in
+                guard let self = self,
+                      let tapBarCoordinator = self.parentCoordinator as? TabBarCoordinator else { return }
+                tapBarCoordinator.moveToChallegeType(type: .auth, challengeID: challengeID)
+            }
+            .store(in: &cancellables)
 
         self.navigationController.pushViewController(homeViewController, animated: false)
     }

--- a/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
@@ -9,6 +9,7 @@ import Combine
 import UIKit
 
 class HomeCoordinator: Coordinator {
+    var parentCoordinator: Coordinator?
     var childCoordinator: [Coordinator] = []
     var navigationController: UINavigationController
     var cancellables = Set<AnyCancellable>()
@@ -21,16 +22,16 @@ class HomeCoordinator: Coordinator {
         let homeViewModel = HomeViewModel(usecase: HomeFetchUsecase())
         let homeViewController = HomeViewController(with: homeViewModel)
         homeViewModel.showChallengeSignal
-            .sink { [weak self] challengeID in
+            .sink { [weak self] _ in
                 let challengeViewController = ChallengeViewController()
                 self?.navigationController.pushViewController(challengeViewController, animated: false)
             }
             .store(in: &cancellables)
         
         homeViewModel.showChallengeDetailSignal
-            .sink { [weak self] _ in
-                let detailViewController = DetailViewController()
-                self?.navigationController.pushViewController(detailViewController, animated: false)
+            .sink { [weak self] challengeID in
+                guard let self = self,
+                      let tapBarCoordinator = self.parentCoordinator else { return }
             }
             .store(in: &cancellables)
         

--- a/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
@@ -23,18 +23,20 @@ class HomeCoordinator: Coordinator {
         let homeViewController = HomeViewController(with: homeViewModel)
         homeViewModel.showChallengeSignal
             .sink { [weak self] _ in
-                let challengeViewController = ChallengeViewController()
-                self?.navigationController.pushViewController(challengeViewController, animated: false)
+                guard let self = self,
+                      let tapBarCoordinator = self.parentCoordinator as? TabBarCoordinator else { return }
+                tapBarCoordinator.moveToChallegeType(type: .main)
             }
             .store(in: &cancellables)
-        
+
         homeViewModel.showChallengeDetailSignal
             .sink { [weak self] challengeID in
                 guard let self = self,
-                      let tapBarCoordinator = self.parentCoordinator else { return }
+                      let tapBarCoordinator = self.parentCoordinator as? TabBarCoordinator else { return }
+                tapBarCoordinator.moveToChallegeType(type: .detail, challengeID: challengeID)
             }
             .store(in: &cancellables)
-        
+
         self.navigationController.pushViewController(homeViewController, animated: false)
     }
 }

--- a/Routinus/Routinus/Application/Coordinator/ManageCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/ManageCoordinator.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 class ManageCoordinator: Coordinator {
+    var parentCoordinator: Coordinator?
     var childCoordinator: [Coordinator] = []
     var navigationController: UINavigationController
 

--- a/Routinus/Routinus/Application/Coordinator/MyPageCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/MyPageCoordinator.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 class MyPageCoordinator: Coordinator {
+    var parentCoordinator: Coordinator?
     var childCoordinator: [Coordinator] = []
     var navigationController: UINavigationController
 

--- a/Routinus/Routinus/Application/Coordinator/TabBarCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/TabBarCoordinator.swift
@@ -12,6 +12,10 @@ class TabBarCoordinator: NSObject, Coordinator {
     var childCoordinator: [Coordinator] = []
     var navigationController: UINavigationController
     var tabBarController: UITabBarController
+    var homeCoordinator: HomeCoordinator?
+    var challengeCoordinator: ChallengeCoordinator?
+    var manageCoordinator: ManageCoordinator?
+    var myPageCoordinator: MyPageCoordinator?
 
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController
@@ -21,6 +25,11 @@ class TabBarCoordinator: NSObject, Coordinator {
 
     func start() {
         configureTabBarController()
+    }
+
+    func moveToChallegeType(type: ChallegeType, challengeID: String? = nil) {
+        self.tabBarController.selectedIndex = 1
+        challengeCoordinator?.moveTo(type: type, challengeID: challengeID)
     }
 
     private func configureTabBarController() {
@@ -37,22 +46,26 @@ class TabBarCoordinator: NSObject, Coordinator {
 
         switch page {
         case .home:
-            let homeCoordinator = HomeCoordinator(navigationController: navigationController)
+            homeCoordinator = HomeCoordinator(navigationController: navigationController)
+            guard let homeCoordinator = homeCoordinator else { return navigationController }
             homeCoordinator.start()
             homeCoordinator.parentCoordinator = self
             self.childCoordinator.append(homeCoordinator)
         case .challenge:
-            let challengeCoordinator = ChallengeCoordinator(navigationController: navigationController)
+            challengeCoordinator = ChallengeCoordinator(navigationController: navigationController)
+            guard let challengeCoordinator = challengeCoordinator else { return navigationController }
             challengeCoordinator.start()
             challengeCoordinator.parentCoordinator = self
             self.childCoordinator.append(challengeCoordinator)
         case .manage:
-            let manageCoordinator = ManageCoordinator(navigationController: navigationController)
+            manageCoordinator = ManageCoordinator(navigationController: navigationController)
+            guard let manageCoordinator = manageCoordinator else { return navigationController }
             manageCoordinator.start()
             manageCoordinator.parentCoordinator = self
             self.childCoordinator.append(manageCoordinator)
         case .myPage:
-            let myPageCoordinator = MyPageCoordinator(navigationController: navigationController)
+            myPageCoordinator = MyPageCoordinator(navigationController: navigationController)
+            guard let myPageCoordinator = myPageCoordinator else { return navigationController }
             myPageCoordinator.start()
             myPageCoordinator.parentCoordinator = self
             self.childCoordinator.append(myPageCoordinator)
@@ -115,4 +128,11 @@ enum TabBarPage {
             return UIImage(systemName: "person.fill")
         }
     }
+}
+
+enum ChallegeType {
+    case main
+    case search
+    case detail
+    case auth
 }

--- a/Routinus/Routinus/Application/Coordinator/TabBarCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/TabBarCoordinator.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 class TabBarCoordinator: NSObject, Coordinator {
+    var parentCoordinator: Coordinator?
     var childCoordinator: [Coordinator] = []
     var navigationController: UINavigationController
     var tabBarController: UITabBarController
@@ -38,18 +39,22 @@ class TabBarCoordinator: NSObject, Coordinator {
         case .home:
             let homeCoordinator = HomeCoordinator(navigationController: navigationController)
             homeCoordinator.start()
+            homeCoordinator.parentCoordinator = self
             self.childCoordinator.append(homeCoordinator)
         case .challenge:
             let challengeCoordinator = ChallengeCoordinator(navigationController: navigationController)
             challengeCoordinator.start()
+            challengeCoordinator.parentCoordinator = self
             self.childCoordinator.append(challengeCoordinator)
         case .manage:
             let manageCoordinator = ManageCoordinator(navigationController: navigationController)
             manageCoordinator.start()
+            manageCoordinator.parentCoordinator = self
             self.childCoordinator.append(manageCoordinator)
         case .myPage:
             let myPageCoordinator = MyPageCoordinator(navigationController: navigationController)
             myPageCoordinator.start()
+            myPageCoordinator.parentCoordinator = self
             self.childCoordinator.append(myPageCoordinator)
         }
 

--- a/Routinus/Routinus/Domain/Entity/AchievementInfo.swift
+++ b/Routinus/Routinus/Domain/Entity/AchievementInfo.swift
@@ -14,6 +14,13 @@ struct AchievementInfo {
     let day: String
     let achievementCount: Int
     let totalCount: Int
+    
+    init(yearMonth: String, day: String, achievementCount: Int, totalCount: Int) {
+        self.yearMonth = yearMonth
+        self.day = day
+        self.achievementCount = achievementCount
+        self.totalCount = totalCount
+    }
 
     init(achievementDTO: AchievementInfoDTO) {
         self.yearMonth = achievementDTO.yearMonth

--- a/Routinus/Routinus/Domain/Entity/TodayRoutine.swift
+++ b/Routinus/Routinus/Domain/Entity/TodayRoutine.swift
@@ -15,6 +15,14 @@ struct TodayRoutine {
     let title: String
     let authCount: Int
     let totalCount: Int
+    
+    init(challengeID: String, category: Category, title: String, authCount: Int, totalCount: Int) {
+        self.challengeID = challengeID
+        self.category = category
+        self.title = title
+        self.authCount = authCount
+        self.totalCount = totalCount
+    }
 
     init(todayRoutineDTO: TodayRoutineDTO) {
         self.challengeID = todayRoutineDTO.challengeID

--- a/Routinus/Routinus/Domain/Usecase/HomeFetchUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/HomeFetchUsecase.swift
@@ -11,47 +11,39 @@ import Foundation
 import RoutinusNetwork
 
 protocol HomeFetchableUsecase {
-    func fetchUserInfo()
-    func fetchTodayRoutine()
-    func fetchAcheivementInfo(yearMonth: String)
-
-    var userInfoSignal: PassthroughSubject<User, Never> { get }
-    var todayRoutineSignal: PassthroughSubject<[TodayRoutine], Never> { get }
-    var achievementSignal: PassthroughSubject<[AchievementInfo], Never> { get }
+    func fetchUserInfo(completion: @escaping (User) -> Void)
+    func fetchTodayRoutine(completion: @escaping ([TodayRoutine]) -> Void)
+    func fetchAcheivementInfo(yearMonth: String, completion: @escaping ([AchievementInfo]) -> Void)
 }
 
 struct HomeFetchUsecase: HomeFetchableUsecase {
-    var userInfoSignal = PassthroughSubject<User, Never>()
-    var todayRoutineSignal = PassthroughSubject<[TodayRoutine], Never>()
-    var achievementSignal = PassthroughSubject<[AchievementInfo], Never>()
-
-    func fetchUserInfo() {
+    func fetchUserInfo(completion: @escaping (User) -> Void) {
         let udid = "BD96E9E9-C0D7-46E6-BDC2-A18705B6E52C"
 
         Task {
             guard let userDTO = try? await RoutinusNetwork.user(of: udid) else { return }
             let userInfo = User(userDTO: userDTO)
-            userInfoSignal.send(userInfo)
+            completion(userInfo)
         }
     }
 
-    func fetchTodayRoutine() {
+    func fetchTodayRoutine(completion: @escaping ([TodayRoutine]) -> Void) {
         let udid = "BD96E9E9-C0D7-46E6-BDC2-A18705B6E52C"
 
         Task {
             guard let list = try? await RoutinusNetwork.routineList(of: udid) else { return }
             let todayRoutine = list.map { TodayRoutine(todayRoutineDTO: $0) }
-            todayRoutineSignal.send(todayRoutine)
+            completion(todayRoutine)
         }
     }
 
-    func fetchAcheivementInfo(yearMonth: String) {
+    func fetchAcheivementInfo(yearMonth: String, completion: @escaping ([AchievementInfo]) -> Void) {
         let udid = "BD96E9E9-C0D7-46E6-BDC2-A18705B6E52C"
 
         Task {
             guard let list = try? await RoutinusNetwork.achievementInfo(of: udid, in: yearMonth) else { return }
             let achievementInfo = list.map { AchievementInfo(achievementDTO: $0) }
-            achievementSignal.send(achievementInfo)
+            completion(achievementInfo)
         }
     }
 }

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -8,10 +8,25 @@
 import UIKit
 
 class AuthViewController: UIViewController {
+    
+    lazy var cntLabel: UILabel = {
+        let label = UILabel()
+        label.text = "AuthView"
+        
+        return label
+    }()
+    
+    private func setupLayout() {
+        self.view.addSubview(cntLabel)
+        self.cntLabel.translatesAutoresizingMaskIntoConstraints = false
+        self.cntLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
+        self.cntLabel.centerYAnchor.constraint(equalTo: self.view.centerYAnchor).isActive = true
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        self.view.backgroundColor = .white
+        setupLayout()
         // Do any additional setup after loading the view.
     }
     

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -329,8 +329,7 @@ extension HomeViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let auth = UIContextualAction(style: .normal, title: "인증하기") { (UIContextualAction, UIView, success: @escaping (Bool) -> Void) in
             // TODO: - 화면 이동하기
-            guard let challengeID = self.viewModel?.todayRoutine.value[indexPath.row].challengeID else { return }
-            self.viewModel?.didTappedTodayRoutineAuth(challengeID: challengeID)
+            self.viewModel?.didTappedTodayRoutineAuth(index: indexPath.row)
         }
         // TODO: - 인증하기 버튼 배경색 정하기
         auth.backgroundColor = .black
@@ -339,7 +338,7 @@ extension HomeViewController: UITableViewDelegate, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let challengeID = viewModel?.todayRoutine.value[indexPath.row].challengeID else { return }
-        self.viewModel?.didTappedTodayRoutine(challengeID: challengeID)
+        self.viewModel?.didTappedTodayRoutine(index: indexPath.row)
     }
 }
 

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -329,6 +329,8 @@ extension HomeViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let auth = UIContextualAction(style: .normal, title: "인증하기") { (UIContextualAction, UIView, success: @escaping (Bool) -> Void) in
             // TODO: - 화면 이동하기
+            guard let challengeID = self.viewModel?.todayRoutine.value[indexPath.row].challengeID else { return }
+            self.viewModel?.didTappedTodayRoutineAuth(challengeID: challengeID)
         }
         // TODO: - 인증하기 버튼 배경색 정하기
         auth.backgroundColor = .black

--- a/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
@@ -45,7 +45,7 @@ class HomeViewModel: HomeViewModelType {
     init(usecase: HomeFetchableUsecase) {
         self.usecase = usecase
         setDateFormatter()
-        self.fetchMyRoutineData()
+        self.fetchMyHomeData()
     }
 }
 
@@ -58,7 +58,7 @@ extension HomeViewModel {
     func didTappedShowChallengeButton() {
         self.showChallengeSignal.send()
     }
-    
+
     func didTappedTodayRoutineAuth(index: Int) {
         let challengeID = self.todayRoutine.value[index].challengeID
         self.showChallengeAuthSignal.send(challengeID)
@@ -66,25 +66,28 @@ extension HomeViewModel {
 }
 
 extension HomeViewModel {
-    func fetchMyRoutineData() {
-        usecase.fetchUserInfo()
-        usecase.fetchTodayRoutine()
-        usecase.fetchAcheivementInfo(yearMonth: Date.currentYearMonth())
+    private func fetchMyHomeData() {
+        fetchUserInfo()
+        fetchTodayRoutine()
+        fetchAcheivementInfo()
+    }
 
-        usecase.userInfoSignal
-            .receive(on: RunLoop.main)
-            .sink { [weak self] userInfo in self?.userInfo.value = userInfo }
-            .store(in: &cancellables)
+    private func fetchUserInfo() {
+        usecase.fetchUserInfo { [weak self] user in
+            self?.userInfo.value = user
+        }
+    }
 
-        usecase.todayRoutineSignal
-            .receive(on: RunLoop.main)
-            .sink { [weak self] routineList in self?.todayRoutine.value = routineList }
-            .store(in: &cancellables)
+    private func fetchTodayRoutine() {
+        usecase.fetchTodayRoutine { [weak self] todayRoutine in
+            self?.todayRoutine.value = todayRoutine
+        }
+    }
 
-        usecase.achievementSignal
-            .receive(on: RunLoop.main)
-            .sink { [weak self] achievementInfo in self?.achievementInfo.value = achievementInfo }
-            .store(in: &cancellables)
+    private func fetchAcheivementInfo() {
+        usecase.fetchAcheivementInfo(yearMonth: Date.currentYearMonth()) { achievementInfo in
+            self.achievementInfo.value = achievementInfo
+        }
     }
 }
 

--- a/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
@@ -9,9 +9,9 @@ import Combine
 import Foundation
 
 protocol HomeViewModelInput {
-    func didTappedTodayRoutine(challengeID: String)
+    func didTappedTodayRoutine(index: Int)
     func didTappedShowChallengeButton()
-    func didTappedTodayRoutineAuth(challengeID: String)
+    func didTappedTodayRoutineAuth(index: Int)
 }
 
 protocol HomeViewModelOutput {
@@ -50,7 +50,8 @@ class HomeViewModel: HomeViewModelType {
 }
 
 extension HomeViewModel {
-    func didTappedTodayRoutine(challengeID: String) {
+    func didTappedTodayRoutine(index: Int) {
+        let challengeID = self.todayRoutine.value[index].challengeID
         self.showChallengeDetailSignal.send(challengeID)
     }
 
@@ -58,7 +59,8 @@ extension HomeViewModel {
         self.showChallengeSignal.send()
     }
     
-    func didTappedTodayRoutineAuth(challengeID: String) {
+    func didTappedTodayRoutineAuth(index: Int) {
+        let challengeID = self.todayRoutine.value[index].challengeID
         self.showChallengeAuthSignal.send(challengeID)
     }
 }

--- a/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
@@ -11,6 +11,7 @@ import Foundation
 protocol HomeViewModelInput {
     func didTappedTodayRoutine(challengeID: String)
     func didTappedShowChallengeButton()
+    func didTappedTodayRoutineAuth(challengeID: String)
 }
 
 protocol HomeViewModelOutput {
@@ -21,6 +22,7 @@ protocol HomeViewModelOutput {
     // coordinator signal
     var showChallengeSignal: PassthroughSubject<Void, Never> { get }
     var showChallengeDetailSignal: PassthroughSubject<String, Never> { get }
+    var showChallengeAuthSignal: PassthroughSubject<String, Never> { get }
     var formatter: DateFormatter { get }
 }
 
@@ -33,6 +35,7 @@ class HomeViewModel: HomeViewModelType {
 
     var showChallengeSignal = PassthroughSubject<Void, Never>()
     var showChallengeDetailSignal = PassthroughSubject<String, Never>()
+    var showChallengeAuthSignal = PassthroughSubject<String, Never>()
 
     var usecase: HomeFetchableUsecase
     var cancellables = Set<AnyCancellable>()
@@ -53,6 +56,10 @@ extension HomeViewModel {
 
     func didTappedShowChallengeButton() {
         self.showChallengeSignal.send()
+    }
+    
+    func didTappedTodayRoutineAuth(challengeID: String) {
+        self.showChallengeAuthSignal.send(challengeID)
     }
 }
 


### PR DESCRIPTION
## 작업 내용

- [x] DetailCoordinator 추가
- [x] 홈화면에서 +, 루틴탭, 인증하기 누를 시 ChallegeTap 이동
- [x] 오늘루틴 및 인증하기 버튼 누를시 challegeID 로직 viewModel이동
- [x] HomeUsecase combine -> completion 로직 수정

## 기타 사항
현재 홈화면탭에서 챌린지 탭의 각각 다른 depth로 이동하는 부분이 많은 것 같습니다.
tapBar를 Home -> Challege를 이동하는 동시에 Challenge화면안의 여러 화면으로 이동하는 로직이 중첩되어 있어
challenge 화면으로 먼저 이동한 후 type에따라 추가화면으로 이동하도록 구현했습니다. <- (이부분은 다시 얘기를 해보면 좋을 것 같습니다)
