### PR TITLE
[공통] 화면이동 수정

### DIFF
--- a/Routinus/Routinus/Application/Coordinator/AppCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/AppCoordinator.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 class AppCoordinator: RoutinusCoordinator {
-    var parentCoordinator: RoutinusCoordinator?
     var childCoordinator: [RoutinusCoordinator] = []
     var navigationController: UINavigationController
 

--- a/Routinus/Routinus/Application/Coordinator/AuthCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/AuthCoordinator.swift
@@ -20,6 +20,6 @@ class AuthCoordinator: RoutinusCoordinator {
 
     func start() {
         let authViewController = AuthViewController()
-        self.navigationController.pushViewController(authViewController, animated: false)
+        self.navigationController.present(authViewController, animated: true)
     }
 }

--- a/Routinus/Routinus/Application/Coordinator/AuthCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/AuthCoordinator.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 class AuthCoordinator: RoutinusCoordinator {
-    var parentCoordinator: RoutinusCoordinator?
     var childCoordinator: [RoutinusCoordinator] = []
     var navigationController: UINavigationController
     let challengeID: String

--- a/Routinus/Routinus/Application/Coordinator/ChallengeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/ChallengeCoordinator.swift
@@ -9,7 +9,6 @@ import Combine
 import UIKit
 
 class ChallengeCoordinator: RoutinusCoordinator {
-    var parentCoordinator: RoutinusCoordinator?
     var childCoordinator: [RoutinusCoordinator] = []
     var navigationController: UINavigationController
     var cancellables = Set<AnyCancellable>()

--- a/Routinus/Routinus/Application/Coordinator/ChallengeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/ChallengeCoordinator.swift
@@ -35,7 +35,8 @@ class ChallengeCoordinator: RoutinusCoordinator {
         challengeViewModel.showChallengeDetailSignal
             .sink { [weak self] challengeID in
                 guard let self = self else { return }
-                let detailCoordinator = DetailCoordinator(navigationController: self.navigationController, challengeID: challengeID)
+                let detailCoordinator = DetailCoordinator(navigationController: self.navigationController,
+                                                          challengeID: challengeID)
                 detailCoordinator.start()
                 self.childCoordinator.append(detailCoordinator)
             }
@@ -44,40 +45,14 @@ class ChallengeCoordinator: RoutinusCoordinator {
         challengeViewModel.showChallengeCategorySignal
             .sink { [weak self] category in
                 guard let self = self else { return }
-                let searchCoordinator = SearchCoordinator(navigationController: self.navigationController, category: category)
+                let searchCoordinator = SearchCoordinator(navigationController: self.navigationController,
+                                                          category: category)
                 searchCoordinator.start()
                 self.childCoordinator.append(searchCoordinator)
             }
             .store(in: &cancellables)
 
         self.navigationController.pushViewController(challengeViewController, animated: false)
-    }
-
-    func moveTo(type: ChallegeType, challengeID: String? = nil) {
-        switch type {
-        case .main:
-            resetToRoot()
-        case .search:
-            resetToRoot()
-        case .detail:
-            resetToRoot()
-            if let challengeID = challengeID {
-                let detailCoordinator = DetailCoordinator(
-                    navigationController: navigationController,
-                    challengeID: challengeID
-                )
-                detailCoordinator.start()
-            }
-        case .auth:
-            resetToRoot()
-            if let challengeID = challengeID {
-                let authCoordinator = AuthCoordinator(
-                    navigationController: navigationController,
-                    challengeID: challengeID
-                )
-                authCoordinator.start()
-            }
-        }
     }
 
     private func resetToRoot() {

--- a/Routinus/Routinus/Application/Coordinator/CreateCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/CreateCoordinator.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 class CreateCoordinator: RoutinusCoordinator {
-    var parentCoordinator: RoutinusCoordinator?
     var childCoordinator: [RoutinusCoordinator] = []
     var navigationController: UINavigationController
 

--- a/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 class DetailCoordinator: RoutinusCoordinator {
-    var parentCoordinator: RoutinusCoordinator?
     var childCoordinator: [RoutinusCoordinator] = []
     var navigationController: UINavigationController
     let challengeID: String

--- a/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
@@ -20,6 +20,13 @@ class DetailCoordinator: RoutinusCoordinator {
 
     func start() {
         let detailViewController = DetailViewController()
-        self.navigationController.pushViewController(detailViewController, animated: false)
+        detailViewController.modalPresentationStyle = .fullScreen
+        let transition = CATransition()
+        transition.duration = 0.35
+        transition.type = CATransitionType.push
+        transition.subtype = CATransitionSubtype.fromRight
+        transition.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
+        self.navigationController.view.window?.layer.add(transition, forKey: kCATransition)
+        self.navigationController.present(detailViewController, animated: false, completion: nil)
     }
 }

--- a/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
@@ -27,16 +27,16 @@ class HomeCoordinator: RoutinusCoordinator {
 
         homeViewModel.showChallengeSignal
             .sink { [weak self] _ in
-                guard let self = self,
-                      let tapBarCoordinator = self.parentCoordinator as? TabBarCoordinator else { return }
-                tapBarCoordinator.moveToChallegeType(type: .main)
+                guard let self = self else { return }
+                self.navigationController.tabBarController?.selectedIndex = 1
             }
             .store(in: &cancellables)
 
         homeViewModel.showChallengeDetailSignal
             .sink { [weak self] challengeID in
                 guard let self = self else { return }
-                let detailCoordinator = DetailCoordinator.init(navigationController: self.navigationController, challengeID: challengeID)
+                let detailCoordinator = DetailCoordinator.init(navigationController: self.navigationController,
+                                                               challengeID: challengeID)
                 detailCoordinator.start()
             }
             .store(in: &cancellables)
@@ -44,7 +44,8 @@ class HomeCoordinator: RoutinusCoordinator {
         homeViewModel.showChallengeAuthSignal
             .sink { [weak self] challengeID in
                 guard let self = self else { return }
-                let authCoordinator = AuthCoordinator.init(navigationController: self.navigationController, challengeID: challengeID)
+                let authCoordinator = AuthCoordinator.init(navigationController: self.navigationController,
+                                                           challengeID: challengeID)
                 authCoordinator.start()
             }
             .store(in: &cancellables)

--- a/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
@@ -35,9 +35,9 @@ class HomeCoordinator: RoutinusCoordinator {
 
         homeViewModel.showChallengeDetailSignal
             .sink { [weak self] challengeID in
-                guard let self = self,
-                      let tapBarCoordinator = self.parentCoordinator as? TabBarCoordinator else { return }
-                tapBarCoordinator.moveToChallegeType(type: .detail, challengeID: challengeID)
+                guard let self = self else { return }
+                let detailCoordinator = DetailCoordinator.init(navigationController: self.navigationController, challengeID: challengeID)
+                detailCoordinator.start()
             }
             .store(in: &cancellables)
 

--- a/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
@@ -9,7 +9,6 @@ import Combine
 import UIKit
 
 class HomeCoordinator: RoutinusCoordinator {
-    var parentCoordinator: RoutinusCoordinator?
     var childCoordinator: [RoutinusCoordinator] = []
     var navigationController: UINavigationController
     var cancellables = Set<AnyCancellable>()

--- a/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
@@ -43,9 +43,9 @@ class HomeCoordinator: RoutinusCoordinator {
 
         homeViewModel.showChallengeAuthSignal
             .sink { [weak self] challengeID in
-                guard let self = self,
-                      let tapBarCoordinator = self.parentCoordinator as? TabBarCoordinator else { return }
-                tapBarCoordinator.moveToChallegeType(type: .auth, challengeID: challengeID)
+                guard let self = self else { return }
+                let authCoordinator = AuthCoordinator.init(navigationController: self.navigationController, challengeID: challengeID)
+                authCoordinator.start()
             }
             .store(in: &cancellables)
 

--- a/Routinus/Routinus/Application/Coordinator/ManageCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/ManageCoordinator.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 class ManageCoordinator: RoutinusCoordinator {
-    var parentCoordinator: RoutinusCoordinator?
     var childCoordinator: [RoutinusCoordinator] = []
     var navigationController: UINavigationController
 

--- a/Routinus/Routinus/Application/Coordinator/MyPageCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/MyPageCoordinator.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 class MyPageCoordinator: RoutinusCoordinator {
-    var parentCoordinator: RoutinusCoordinator?
     var childCoordinator: [RoutinusCoordinator] = []
     var navigationController: UINavigationController
 

--- a/Routinus/Routinus/Application/Coordinator/RoutinusCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/RoutinusCoordinator.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 protocol RoutinusCoordinator: AnyObject {
-    var parentCoordinator: RoutinusCoordinator? { get set }
     var childCoordinator: [RoutinusCoordinator] { get set }
     var navigationController: UINavigationController { get }
 

--- a/Routinus/Routinus/Application/Coordinator/SearchCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/SearchCoordinator.swift
@@ -9,7 +9,6 @@ import Combine
 import UIKit
 
 class SearchCoordinator: RoutinusCoordinator {
-    var parentCoordinator: RoutinusCoordinator?
     var childCoordinator: [RoutinusCoordinator] = []
     var navigationController: UINavigationController
     var cancellables = Set<AnyCancellable>()

--- a/Routinus/Routinus/Application/Coordinator/TabBarCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/TabBarCoordinator.swift
@@ -12,10 +12,6 @@ class TabBarCoordinator: NSObject, RoutinusCoordinator {
     var childCoordinator: [RoutinusCoordinator] = []
     var navigationController: UINavigationController
     var tabBarController: UITabBarController
-    var homeCoordinator: HomeCoordinator?
-    var challengeCoordinator: ChallengeCoordinator?
-    var manageCoordinator: ManageCoordinator?
-    var myPageCoordinator: MyPageCoordinator?
 
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController
@@ -41,26 +37,22 @@ class TabBarCoordinator: NSObject, RoutinusCoordinator {
 
         switch page {
         case .home:
-            homeCoordinator = HomeCoordinator(navigationController: navigationController)
-            guard let homeCoordinator = homeCoordinator else { return navigationController }
+            let homeCoordinator = HomeCoordinator(navigationController: navigationController)
             homeCoordinator.start()
             homeCoordinator.parentCoordinator = self
             self.childCoordinator.append(homeCoordinator)
         case .challenge:
-            challengeCoordinator = ChallengeCoordinator(navigationController: navigationController)
-            guard let challengeCoordinator = challengeCoordinator else { return navigationController }
+            let challengeCoordinator = ChallengeCoordinator(navigationController: navigationController)
             challengeCoordinator.start()
             challengeCoordinator.parentCoordinator = self
             self.childCoordinator.append(challengeCoordinator)
         case .manage:
-            manageCoordinator = ManageCoordinator(navigationController: navigationController)
-            guard let manageCoordinator = manageCoordinator else { return navigationController }
+            let manageCoordinator = ManageCoordinator(navigationController: navigationController)
             manageCoordinator.start()
             manageCoordinator.parentCoordinator = self
             self.childCoordinator.append(manageCoordinator)
         case .myPage:
-            myPageCoordinator = MyPageCoordinator(navigationController: navigationController)
-            guard let myPageCoordinator = myPageCoordinator else { return navigationController }
+            let myPageCoordinator = MyPageCoordinator(navigationController: navigationController)
             myPageCoordinator.start()
             myPageCoordinator.parentCoordinator = self
             self.childCoordinator.append(myPageCoordinator)
@@ -123,11 +115,4 @@ enum TabBarPage {
             return UIImage(systemName: "person.fill")
         }
     }
-}
-
-enum ChallegeType {
-    case main
-    case search
-    case detail
-    case auth
 }

--- a/Routinus/Routinus/Application/Coordinator/TabBarCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/TabBarCoordinator.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 class TabBarCoordinator: NSObject, RoutinusCoordinator {
-    var parentCoordinator: RoutinusCoordinator?
     var childCoordinator: [RoutinusCoordinator] = []
     var navigationController: UINavigationController
     var tabBarController: UITabBarController
@@ -39,22 +38,18 @@ class TabBarCoordinator: NSObject, RoutinusCoordinator {
         case .home:
             let homeCoordinator = HomeCoordinator(navigationController: navigationController)
             homeCoordinator.start()
-            homeCoordinator.parentCoordinator = self
             self.childCoordinator.append(homeCoordinator)
         case .challenge:
             let challengeCoordinator = ChallengeCoordinator(navigationController: navigationController)
             challengeCoordinator.start()
-            challengeCoordinator.parentCoordinator = self
             self.childCoordinator.append(challengeCoordinator)
         case .manage:
             let manageCoordinator = ManageCoordinator(navigationController: navigationController)
             manageCoordinator.start()
-            manageCoordinator.parentCoordinator = self
             self.childCoordinator.append(manageCoordinator)
         case .myPage:
             let myPageCoordinator = MyPageCoordinator(navigationController: navigationController)
             myPageCoordinator.start()
-            myPageCoordinator.parentCoordinator = self
             self.childCoordinator.append(myPageCoordinator)
         }
 

--- a/Routinus/Routinus/Application/Coordinator/TabBarCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/TabBarCoordinator.swift
@@ -27,11 +27,6 @@ class TabBarCoordinator: NSObject, RoutinusCoordinator {
         configureTabBarController()
     }
 
-    func moveToChallegeType(type: ChallegeType, challengeID: String? = nil) {
-        self.tabBarController.selectedIndex = 1
-        challengeCoordinator?.moveTo(type: type, challengeID: challengeID)
-    }
-
     private func configureTabBarController() {
         let pages: [TabBarPage] = [.home, .challenge, .manage, .myPage]
         let controllers: [UINavigationController] = pages.map { getTabBarController($0) }

--- a/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
+++ b/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
@@ -9,6 +9,14 @@ import UIKit
 
 class DetailViewController: UIViewController {
 
+    private lazy var backButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "chevron.backward"), for: .normal)
+        button.addTarget(self, action: #selector(didTouchbackButton), for: .touchUpInside)
+        button.tintColor = UIColor.black
+        return button
+    }()
+
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage(named: "ChallengeDetailView")
@@ -31,5 +39,22 @@ class DetailViewController: UIViewController {
         imageView.snp.makeConstraints { make in
             make.edges.equalTo(self.view.safeAreaLayoutGuide).inset(20)
         }
+
+        self.view.addSubview(backButton)
+        backButton.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(70)
+            make.leading.equalToSuperview().offset(30)
+        }
     }
+
+    @objc func didTouchbackButton() {
+        let transition = CATransition()
+        transition.duration = 0.35
+        transition.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
+        transition.type = CATransitionType.push
+        transition.subtype = CATransitionSubtype.fromLeft
+        self.view.window!.layer.add(transition, forKey: nil)
+        self.dismiss(animated: false)
+    }
+
 }

--- a/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
+++ b/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
@@ -16,6 +16,14 @@ class DetailViewController: UIViewController {
         button.tintColor = UIColor.black
         return button
     }()
+    
+    private lazy var authButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("인증하기", for: .normal)
+        button.setTitleColor(UIColor.black, for: .normal)
+        button.addTarget(self, action: #selector(didTouchAuthButton), for: .touchUpInside)
+        return button
+    }()
 
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
@@ -45,6 +53,12 @@ class DetailViewController: UIViewController {
             make.top.equalToSuperview().offset(70)
             make.leading.equalToSuperview().offset(30)
         }
+        
+        self.view.addSubview(authButton)
+        authButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalToSuperview().offset(-90)
+        }
     }
 
     @objc func didTouchbackButton() {
@@ -55,6 +69,11 @@ class DetailViewController: UIViewController {
         transition.subtype = CATransitionSubtype.fromLeft
         self.view.window!.layer.add(transition, forKey: nil)
         self.dismiss(animated: false)
+    }
+
+    @objc func didTouchAuthButton() {
+        let authViewController = AuthViewController()
+        self.present(authViewController, animated: true, completion: nil)
     }
 
 }


### PR DESCRIPTION
## 작업 내용

- [x] 상세화면 fullscreen Modal 적용
- [x] 인증화면 밑에서 위로 modal 적용
- [x] Coordinator parentCoordinator 제거 

- contents
기존 홈화면에서 상세화면과 인증화면의 화면이동 부분이동이 챌린지 탭바를 거처가는 부분에서 부자연스럽다고 생각하여
fullScreen과 modal을 사용해서 표시하는 방안으로 수정했습니다.
로직적인 부분에서도 더 간단해지고 화면 이동도 더욱 직관적으로 변경된 것 같습니다.