### PR TITLE
[챌린지 추가 화면] 챌린지 기간이 53주가 넘어가면 53주로 고정 

### DIFF
--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -220,11 +220,14 @@ extension CreateViewController: UITextFieldDelegate, UITextViewDelegate {
     }
     
     func textFieldDidChangeSelection(_ textField: UITextField) {
+        guard let viewModel = viewModel else { return }
         switch textField.tag {
         case InputTag.title.rawValue:
-            viewModel?.update(title: textField.text ?? "")
+            viewModel.update(title: textField.text ?? "")
         case InputTag.week.rawValue:
-            viewModel?.update(week: Int(textField.text ?? "") ?? 0)
+            let week = viewModel.validateWeek(currentText: textField.text ?? "")
+            textField.text = week
+            viewModel.update(week: Int(week) ?? 0)
         default:
             return
         }

--- a/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
@@ -19,6 +19,7 @@ protocol CreateViewModelInput {
     func didTappedCreateButton()
     func validateTextView(currentText: String, range: NSRange, text: String) -> Bool
     func validateTextField(currentText: String, range: NSRange, text: String) -> Bool
+    func validateWeek(currentText: String) -> String
 }
 
 protocol CreateViewModelOutput {
@@ -69,6 +70,11 @@ class CreateViewModel: CreateViewModelIO {
     func validateTextField(currentText: String, range: NSRange, text: String) -> Bool {
         let newLength = currentText.count + text.count - range.length
         return newLength <= 50
+    }
+
+    func validateWeek(currentText: String) -> String {
+        guard let week = Int(currentText) else { return "" }
+        return "\(min(max(week, 0), 53))"
     }
 
     func update(category: Challenge.Category) {

--- a/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
@@ -74,7 +74,7 @@ class CreateViewModel: CreateViewModelIO {
 
     func validateWeek(currentText: String) -> String {
         guard let week = Int(currentText) else { return "" }
-        return "\(min(max(week, 0), 53))"
+        return "\(min(max(week, 0), 52))"
     }
 
     func update(category: Challenge.Category) {

--- a/Routinus/Routinus/Presentation/Create/Subviews/CreateWeekView.swift
+++ b/Routinus/Routinus/Presentation/Create/Subviews/CreateWeekView.swift
@@ -21,7 +21,7 @@ final class CreateWeekView: UIView {
 
     private lazy var descriptionLabel: UILabel = {
         let label = UILabel()
-        label.text = "주 단위로 숫자만 입력해주세요."
+        label.text = "주 단위로 숫자만 입력해주세요. (최대 53주)"
         label.font = .systemFont(ofSize: 16)
         label.textColor = .systemGray
         return label
@@ -31,6 +31,7 @@ final class CreateWeekView: UIView {
         let textField = UITextField()
         textField.text = "1"
         textField.borderStyle = .roundedRect
+        textField.keyboardType = .numberPad
         textField.textAlignment = .center
         textField.tag = Tag.week.rawValue
         return textField

--- a/Routinus/Routinus/Presentation/Create/Subviews/CreateWeekView.swift
+++ b/Routinus/Routinus/Presentation/Create/Subviews/CreateWeekView.swift
@@ -21,7 +21,7 @@ final class CreateWeekView: UIView {
 
     private lazy var descriptionLabel: UILabel = {
         let label = UILabel()
-        label.text = "주 단위로 숫자만 입력해주세요. (최대 53주)"
+        label.text = "주 단위로 숫자만 입력해주세요. (최대 52주)"
         label.font = .systemFont(ofSize: 16)
         label.textColor = .systemGray
         return label


### PR DESCRIPTION
## 작업 내용
- [x] CreateViewModel애 챌린지 기간 체크하는 메소드 추가 
- [x] 챌린지 기간 TextField 터치 시 숫자 키보드가 보이도록 변경 

## 작업 결과
https://user-images.githubusercontent.com/83990431/141663592-893ffe0a-8630-4825-a6ee-1d8094bb8a26.mov
- 사용자의 입력 값이 53보다 크면 53주로 고정시켰습니다 
