### PR TITLE
[공통] NavigationBar 뒤로가기 버튼 및 Large title 수정

### DIFF
--- a/Routinus/Routinus/Application/Coordinator/ChallengeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/ChallengeCoordinator.swift
@@ -30,7 +30,7 @@ final class ChallengeCoordinator: RoutinusCoordinator {
                 self.childCoordinator.append(searchCoordinator)
             }
             .store(in: &cancellables)
-        
+
         challengeViewModel.seeAllButtonTap
             .sink { [weak self] _ in
                 guard let self = self else { return }
@@ -61,9 +61,5 @@ final class ChallengeCoordinator: RoutinusCoordinator {
             .store(in: &cancellables)
 
         self.navigationController.pushViewController(challengeViewController, animated: false)
-    }
-
-    private func resetToRoot() {
-        self.navigationController.popToRootViewController(animated: false)
     }
 }

--- a/Routinus/Routinus/Application/Coordinator/SearchCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/SearchCoordinator.swift
@@ -24,7 +24,7 @@ final class SearchCoordinator: RoutinusCoordinator {
         let searchUsecase = SearchFetchUsecase(repository: repository)
         let searchViewModel = SearchViewModel(category: category, usecase: searchUsecase)
         let searchViewController = SearchViewController(with: searchViewModel)
-        self.navigationController.pushViewController(searchViewController, animated: false)
+        self.navigationController.pushViewController(searchViewController, animated: true)
 
         searchViewModel.challengeTap
             .sink { [weak self] challengeID in

--- a/Routinus/Routinus/Presentation/Challenge/ChallengeViewController.swift
+++ b/Routinus/Routinus/Presentation/Challenge/ChallengeViewController.swift
@@ -85,8 +85,8 @@ final class ChallengeViewController: UIViewController {
         self.searchButton.isHidden = false
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         self.searchButton.isHidden = true
     }
 }

--- a/Routinus/Routinus/Presentation/Challenge/ChallengeViewController.swift
+++ b/Routinus/Routinus/Presentation/Challenge/ChallengeViewController.swift
@@ -153,7 +153,7 @@ extension ChallengeViewController {
         self.navigationItem.largeTitleDisplayMode = .always
         self.navigationItem.title = "Challenges"
         let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
-        backBarButtonItem.tintColor = .systemGray
+        backBarButtonItem.tintColor = .black
         self.navigationItem.backBarButtonItem = backBarButtonItem
     }
 

--- a/Routinus/Routinus/Presentation/Challenge/ChallengeViewController.swift
+++ b/Routinus/Routinus/Presentation/Challenge/ChallengeViewController.swift
@@ -147,11 +147,14 @@ extension ChallengeViewController {
             make.edges.equalToSuperview()
         }
     }
-    
+
     private func configureNavigationBar() {
         self.navigationController?.navigationBar.prefersLargeTitles = true
-        self.navigationController?.navigationItem.largeTitleDisplayMode = .always
+        self.navigationItem.largeTitleDisplayMode = .always
         self.navigationItem.title = "Challenges"
+        let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
+        backBarButtonItem.tintColor = .systemGray
+        self.navigationItem.backBarButtonItem = backBarButtonItem
     }
 
     private func configureSearchButton() {

--- a/Routinus/Routinus/Presentation/Challenge/ChallengeViewController.swift
+++ b/Routinus/Routinus/Presentation/Challenge/ChallengeViewController.swift
@@ -140,13 +140,18 @@ extension ChallengeViewController {
 
     private func configureViews() {
         self.view.backgroundColor = .systemBackground
-        self.navigationController?.navigationBar.prefersLargeTitles = true
-        self.navigationItem.title = "Challenges"
+        self.configureNavigationBar()
         self.configureSearchButton()
         self.view.addSubview(collectionView)
         self.collectionView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
+    }
+    
+    private func configureNavigationBar() {
+        self.navigationController?.navigationBar.prefersLargeTitles = true
+        self.navigationController?.navigationItem.largeTitleDisplayMode = .always
+        self.navigationItem.title = "Challenges"
     }
 
     private func configureSearchButton() {

--- a/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
+++ b/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
@@ -36,12 +36,13 @@ final class DetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = .white
-        self.navigationController?.navigationBar.prefersLargeTitles = false
         self.configureViews()
     }
 
     func configureViews() {
         self.view.backgroundColor = .white
+        self.configureNavigationBar()
+
         self.view.addSubview(imageView)
         imageView.snp.makeConstraints { make in
             make.edges.equalTo(self.view.safeAreaLayoutGuide).inset(20)
@@ -58,6 +59,10 @@ final class DetailViewController: UIViewController {
             make.centerX.equalToSuperview()
             make.bottom.equalToSuperview().offset(-90)
         }
+    }
+
+    private func configureNavigationBar() {
+        self.navigationItem.largeTitleDisplayMode = .never
     }
 
     @objc func didTouchbackButton() {

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -44,7 +44,7 @@ final class HomeViewController: UIViewController {
 extension HomeViewController {
     private func configureViews() {
         self.view.backgroundColor = .white
-        self.navigationController?.navigationBar.prefersLargeTitles = true
+        self.configureNavigationBar()
 
         self.view.addSubview(scrollView)
         self.scrollView.snp.makeConstraints { make in
@@ -79,6 +79,14 @@ extension HomeViewController {
             make.height.equalTo(350)
             make.bottom.equalToSuperview().offset(-50)
         }
+    }
+    
+    private func configureNavigationBar() {
+        self.navigationController?.navigationBar.prefersLargeTitles = true
+        self.navigationItem.largeTitleDisplayMode = .always
+        let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
+        backBarButtonItem.tintColor = .systemGray
+        self.navigationItem.backBarButtonItem = backBarButtonItem
     }
 
     private func configureViewModel() {

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -85,7 +85,7 @@ extension HomeViewController {
         self.navigationController?.navigationBar.prefersLargeTitles = true
         self.navigationController?.navigationItem.largeTitleDisplayMode = .always
         let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
-        backBarButtonItem.tintColor = .systemGray
+        backBarButtonItem.tintColor = .black
         self.navigationItem.backBarButtonItem = backBarButtonItem
     }
 

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -80,10 +80,10 @@ extension HomeViewController {
             make.bottom.equalToSuperview().offset(-50)
         }
     }
-    
+
     private func configureNavigationBar() {
         self.navigationController?.navigationBar.prefersLargeTitles = true
-        self.navigationItem.largeTitleDisplayMode = .always
+        self.navigationController?.navigationItem.largeTitleDisplayMode = .always
         let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
         backBarButtonItem.tintColor = .systemGray
         self.navigationItem.backBarButtonItem = backBarButtonItem

--- a/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
+++ b/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
@@ -56,7 +56,7 @@ final class ManageViewController: UIViewController {
 
     private func configureNavigationBar() {
         let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
-        backBarButtonItem.tintColor = .systemGray
+        backBarButtonItem.tintColor = .black
         self.navigationItem.backBarButtonItem = backBarButtonItem
     }
 }

--- a/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
+++ b/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
@@ -50,5 +50,13 @@ final class ManageViewController: UIViewController {
             make.top.equalTo(imageView).offset(30)
             make.trailing.equalTo(imageView).offset(-20)
         }
+        
+        self.configureNavigationBar()
+    }
+
+    private func configureNavigationBar() {
+        let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
+        backBarButtonItem.tintColor = .systemGray
+        self.navigationItem.backBarButtonItem = backBarButtonItem
     }
 }

--- a/Routinus/Routinus/Presentation/Search/SearchViewController.swift
+++ b/Routinus/Routinus/Presentation/Search/SearchViewController.swift
@@ -52,20 +52,6 @@ final class SearchViewController: UIViewController {
 
         return collectionView
     }()
-    
-    lazy var backButtonImage: UIImage? = {
-        let image = UIImage(systemName: "chevron.backward")?
-            .withAlignmentRectInsets(UIEdgeInsets(top: 0.0, left: -12.0, bottom: -5.0, right: 0.0))
-        return image
-    }()
-
-    private var backButtonAppearance: UIBarButtonItemAppearance {
-        let backButtonAppearance = UIBarButtonItemAppearance()
-        backButtonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.clear,
-                                                           .font: UIFont.systemFont(ofSize: 0.0)]
-
-        return backButtonAppearance
-    }
 
     init(with viewModel: SearchViewModelIO) {
         super.init(nibName: nil, bundle: nil)
@@ -132,7 +118,7 @@ extension SearchViewController {
     private func configureViews() {
         self.view.backgroundColor = .systemBackground
         self.view.addSubview(collectionView)
-        self.setNavigationBarAppearance()
+        self.configureNavigationBar()
         self.configureKeyboard()
         self.collectionView.snp.makeConstraints { make in
             make.leading.top.trailing.equalToSuperview()
@@ -164,21 +150,11 @@ extension SearchViewController {
             .store(in: &cancellables)
     }
 
-    private func setNavigationBarAppearance() {
-        let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = .systemBackground
-        appearance.setBackIndicatorImage(backButtonImage, transitionMaskImage: backButtonImage)
-        appearance.backButtonAppearance = backButtonAppearance
-
+    private func configureNavigationBar() {
         self.searchBarView.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 44)
         self.navigationItem.titleView = searchBarView
         self.navigationController?.navigationBar.shadowImage = UIImage()
-        self.navigationController?.navigationBar.prefersLargeTitles = false
-        self.navigationController?.navigationBar.standardAppearance = appearance
-        self.navigationController?.navigationBar.compactAppearance = appearance
-        self.navigationController?.navigationBar.scrollEdgeAppearance = appearance
-        self.navigationController?.navigationBar.isTranslucent = false
-        self.navigationController?.navigationBar.tintColor = .black
+        self.navigationItem.largeTitleDisplayMode = .never
     }
 
     static func createLayout() -> UICollectionViewCompositionalLayout {


### PR DESCRIPTION
## 관련 issue

#132
#188
#189

## 작업 내용

- [x] 챌린지 검색 화면 NavigationBar 하단 라인 표시 삭제
- [x] 홈화면 및 챌린지 화면 Navigation 다시 돌아올 시 Large title 설정
- [x] BackButtonItem 전체 적용  

## 기타 사항

LargeTitle을 Navigation과 같이 사용할 시 viewWillAppear, viewWillDisappear에서 처리해주는 것이 아니라
viewDidLoad에서 처리해줘야하는 이슈가 있었습니다.

또한 LargeTitle을 사용하는 화면에서는
```swift
self.navigationController?.navigationBar.prefersLargeTitles = true
self.navigationItem.largeTitleDisplayMode = .always
```

LargeTitle을 사용하지 않는 화면에서는
```swift
// self.navigationController?.navigationBar.prefersLargeTitles = false // false를 적용하면 LargeTitle이 돌아가면서 초기화된다. 사용X
self.navigationItem.largeTitleDisplayMode = .never // never만 사용
```


