### PR TITLE
[챌린지 검색 화면] 이미지 캐싱 구현

### DIFF
--- a/Routinus/Podfile
+++ b/Routinus/Podfile
@@ -8,5 +8,4 @@ target 'Routinus' do
   # Pods for Routinus
   pod 'SwiftLint', '0.45.0'
   pod 'SnapKit', '5.0.1'
-  pod 'Kingfisher', '7.0'
 end

--- a/Routinus/Routinus/Domain/Usecase/SearchFetchUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/SearchFetchUsecase.swift
@@ -10,8 +10,13 @@ import Foundation
 protocol SearchFetchableUsecase {
     func fetchPopularKeywords(completion: @escaping ([String]) -> Void)
     func fetchLatestChallenges(completion: @escaping ([Challenge]) -> Void)
-    func fetchSearchChallenges(keyword: String, completion: @escaping ([Challenge]) -> Void)
-    func fetchSearchChallenges(category: Challenge.Category, completion: @escaping ([Challenge]) -> Void)
+    func fetchSearchChallenges(keyword: String,
+                               completion: @escaping ([Challenge]) -> Void)
+    func fetchSearchChallenges(category: Challenge.Category,
+                               completion: @escaping ([Challenge]) -> Void)
+    func fetchImageData(from directory: String,
+                        filename: String,
+                        completion: ((Data?) -> Void)?)
 }
 
 struct SearchFetchUsecase: SearchFetchableUsecase {
@@ -58,6 +63,14 @@ struct SearchFetchUsecase: SearchFetchableUsecase {
             let challenges = list
                 .filter { $0.category == category }
             completion(challenges)
+        }
+    }
+
+    func fetchImageData(from directory: String,
+                        filename: String,
+                        completion: ((Data?) -> Void)? = nil) {
+        repository.fetchImageData(from: directory, filename: filename) { data in
+            completion?(data)
         }
     }
 

--- a/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
+++ b/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
@@ -111,8 +111,9 @@ extension ManageViewController {
     private func configureDataSource() -> DataSource {
         let dataSource = DataSource(collectionView: self.collectionView) { collectionView, indexPath, challenge in
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SearchChallengeCell.identifier,
-                                                              for: indexPath) as? SearchChallengeCell
-            cell?.configureViews(challenge: challenge)
+                                                          for: indexPath) as? SearchChallengeCell
+            cell?.setTitle(challenge.title)
+            // TODO: setImage(SearchVC 로직 merge되면 구현)
             return cell
         }
         return dataSource

--- a/Routinus/Routinus/Presentation/Search/Cells/SearchChallengeCell.swift
+++ b/Routinus/Routinus/Presentation/Search/Cells/SearchChallengeCell.swift
@@ -8,13 +8,12 @@
 import UIKit
 
 import SnapKit
-import Kingfisher
 import RoutinusDatabase
 
 final class SearchChallengeCell: UICollectionViewCell {
     static let identifier = "SearchChallengeCell"
 
-    private lazy var challengeImageView: UIImageView = {
+    private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
@@ -30,11 +29,29 @@ final class SearchChallengeCell: UICollectionViewCell {
         return label
     }()
 
-    func configureViews(challenge: Challenge) {
-        self.titleLabel.text = challenge.title
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureViews()
+    }
 
-        self.addSubview(challengeImageView)
-        self.challengeImageView.snp.makeConstraints { make in
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureViews()
+    }
+
+    func setTitle(_ title: String) {
+        titleLabel.text = title
+    }
+
+    func setImage(_ image: UIImage) {
+        imageView.image = image
+    }
+}
+
+extension SearchChallengeCell {
+    private func configureViews() {
+        self.addSubview(imageView)
+        self.imageView.snp.makeConstraints { make in
             make.top.leading.trailing.equalToSuperview()
             make.height.equalTo(110)
         }
@@ -42,15 +59,7 @@ final class SearchChallengeCell: UICollectionViewCell {
         self.addSubview(titleLabel)
         self.titleLabel.snp.makeConstraints { make in
             make.leading.bottom.equalToSuperview()
-            make.top.equalTo(challengeImageView.snp.bottom).offset(10)
-        }
-
-        // TODO: RoutinusDatabase 직접 접근하지 않도록 수정
-        Task {
-            let url = try? await RoutinusDatabase.imageURL(id: challenge.challengeID, filename: "image")
-
-            self.challengeImageView.kf.setImage(with: url,
-                                                placeholder: nil)
+            make.top.equalTo(imageView.snp.bottom).offset(10)
         }
     }
 }

--- a/Routinus/Routinus/Presentation/Search/SearchViewController.swift
+++ b/Routinus/Routinus/Presentation/Search/SearchViewController.swift
@@ -88,7 +88,16 @@ extension SearchViewController {
             case .challenge(let challenge):
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SearchChallengeCell.identifier,
                                                               for: indexPath) as? SearchChallengeCell
-                cell?.configureViews(challenge: challenge)
+                cell?.setTitle(challenge.title)
+                self.viewModel?.imageData(from: challenge.challengeID,
+                                     filename: "thumbnail_image") { data in
+                    guard let data = data else { return }
+                    guard let image = UIImage(data: data) else { return }
+
+                    DispatchQueue.main.async {
+                        cell?.setImage(image)
+                    }
+                }
                 return cell
             }
         }

--- a/Routinus/Routinus/Presentation/Search/SearchViewModel.swift
+++ b/Routinus/Routinus/Presentation/Search/SearchViewModel.swift
@@ -11,6 +11,9 @@ import Foundation
 protocol SearchViewModelInput {
     func didChangedSearchText(_ keyword: String)
     func didTappedChallenge(index: Int)
+    func imageData(from directory: String,
+                   filename: String,
+                   completion: ((Data?) -> Void)?)
 }
 
 protocol SearchViewModelOutput {
@@ -57,6 +60,14 @@ extension SearchViewModel {
     func didTappedChallenge(index: Int) {
         let challengeID = self.challenges.value[index].challengeID
         challengeTap.send(challengeID)
+    }
+
+    func imageData(from directory: String,
+                   filename: String,
+                   completion: ((Data?) -> Void)? = nil) {
+        usecase.fetchImageData(from: directory, filename: filename) { data in
+            completion?(data)
+        }
     }
 }
 

--- a/Routinus/RoutinusDatabase/RoutinusDatabase.swift
+++ b/Routinus/RoutinusDatabase/RoutinusDatabase.swift
@@ -9,6 +9,7 @@ import Foundation
 
 public enum RoutinusDatabase {
     private enum HTTPMethod: String {
+        case get = "GET"
         case post = "POST"
         case patch = "PATCH"
     }
@@ -17,7 +18,7 @@ public enum RoutinusDatabase {
     private static let storageURL = "https://firebasestorage.googleapis.com/v0/b/boostcamp-ios03-routinus.appspot.com/o"
 
     public static func imageURL(id: String,
-                                filename: String) async throws -> URL? {
+                                filename: String) -> URL? {
         return URL(string: "\(storageURL)/\(id)%2F\(filename).jpeg?alt=media")
     }
 
@@ -110,6 +111,22 @@ public enum RoutinusDatabase {
 
         URLSession.shared.dataTask(with: request) { _, _, _ in
             completion?()
+        }.resume()
+    }
+
+    public static func imageData(from id: String,
+                                 filename: String,
+                                 completion: ((Data?) -> Void)? = nil) {
+        guard let url = imageURL(id: id, filename: filename) else {
+            completion?(nil)
+            return
+        }
+        var request = URLRequest(url: url)
+
+        request.httpMethod = HTTPMethod.get.rawValue
+
+        URLSession.shared.dataTask(with: request) { data, _, _ in
+            completion?(data)
         }.resume()
     }
 

--- a/Routinus/RoutinusImageManager/RoutinusImageManager.swift
+++ b/Routinus/RoutinusImageManager/RoutinusImageManager.swift
@@ -29,20 +29,23 @@ public enum RoutinusImageManager {
         return (try? FileManager.default.contentsOfDirectory(atPath: url.path)) ?? []
     }
 
-    // TODO: 제대로 동작하는지 테스트 필요
-    public static func cachedImageData(from directory: String, filename: String) -> Data? {
+    public static func cachedImageData(from directory: String,
+                                       filename: String,
+                                       completion: ((Data?) -> Void)? = nil) {
         guard let path = NSSearchPathForDirectoriesInDomains(.cachesDirectory,
                                                              .userDomainMask,
-                                                             true).first else { return nil }
+                                                             true).first else {
+            completion?(nil)
+            return
+        }
 
         var url = URL(fileURLWithPath: path)
         url.appendPathComponent("\(directory)_\(filename)")
         url.appendPathExtension("jpeg")
 
-        return try? Data(contentsOf: url)
+        completion?(try? Data(contentsOf: url))
     }
 
-    // TODO: 제대로 동작하는지 테스트 필요
     public static func cachedImageURL(from directory: String, filename: String) -> String {
         guard let path = NSSearchPathForDirectoriesInDomains(.cachesDirectory,
                                                              .userDomainMask,
@@ -90,7 +93,6 @@ public enum RoutinusImageManager {
 
 // TODO: 개발 완료 후 삭제(개발/테스트용으로 작성된 메소드)
 extension RoutinusImageManager {
-    // TODO: 제대로 동작하는지 테스트 필요
     public static func removeAllCachedImages() {
         guard let path = NSSearchPathForDirectoriesInDomains(.cachesDirectory,
                                                              .userDomainMask,


### PR DESCRIPTION
## 관련 issue

close #146
close #147

## 작업 내용

- [x] 검색 화면 cell에 thumbnail 이미지를 적용하는 기능 구현
- [x] 캐싱된 이미지가 있을 경우 캐싱된 이미지로 적용
- [x] 캐싱된 이미지가 없을 경우 firebase storage에 저장된 이미지를 받아와서 적용
- [x] Kingfisher 라이브러리 제거

## 기타 사항

- Manage 화면에도 같은 로직이 있는데, 피드백 받고 merge한 후 적용하겠습니다.
- thumbnail이 없는 기존 챌린지들은 이미지가 출력되지 않습니다. (새로 추가하면 잘 보입니다)