### PR TITLE
[챌린지 검색 화면] 멘토링 사항 수정 및 검색 화면 fetch 수정

### DIFF
--- a/Routinus/Routinus/Presentation/Challenge/Cells/ChallengeCategoryCell.swift
+++ b/Routinus/Routinus/Presentation/Challenge/Cells/ChallengeCategoryCell.swift
@@ -21,135 +21,15 @@ final class ChallengeCategoryCell: UICollectionViewCell {
     private lazy var xStackView1: UIStackView = {
         let stack = UIStackView()
         stack.axis = .horizontal
-        stack.spacing = 30
+        stack.distribution = .equalSpacing
         return stack
     }()
 
     private lazy var xStackView2: UIStackView = {
         let stack = UIStackView()
         stack.axis = .horizontal
-        stack.spacing = 30
+        stack.distribution = .equalSpacing
         return stack
-    }()
-
-    private lazy var exerciseButton: CategoryButton = {
-        let button = CategoryButton()
-        let category = Challenge.Category.exercise
-        button.setImage(UIImage(named: category.symbol))
-        button.setTitle(category.title)
-        button.setTintColor(UIColor(named: category.color))
-
-        let gesture = CategoryButtonTapGesture(target: self, action: #selector(didTappedCategoryButton))
-        gesture.numberOfTapsRequired = 1
-        gesture.configureCategory(category: category)
-        self.isUserInteractionEnabled = true
-        button.addGestureRecognizer(gesture)
-        return button
-    }()
-
-    private lazy var studyButton: CategoryButton = {
-        let button = CategoryButton()
-        let category = Challenge.Category.study
-        button.setImage(UIImage(systemName: category.symbol))
-        button.setTitle(category.title)
-        button.setTintColor(UIColor(named: category.color))
-
-        let gesture = CategoryButtonTapGesture(target: self, action: #selector(didTappedCategoryButton))
-        gesture.numberOfTapsRequired = 1
-        gesture.configureCategory(category: category)
-        self.isUserInteractionEnabled = true
-        button.addGestureRecognizer(gesture)
-        return button
-    }()
-
-    private lazy var readButton: CategoryButton = {
-        let button = CategoryButton()
-        let category = Challenge.Category.read
-        button.setImage(UIImage(systemName: category.symbol))
-        button.setTitle(category.title)
-        button.setTintColor(UIColor(named: category.color))
-
-        let gesture = CategoryButtonTapGesture(target: self, action: #selector(didTappedCategoryButton))
-        gesture.numberOfTapsRequired = 1
-        gesture.configureCategory(category: category)
-        self.isUserInteractionEnabled = true
-        button.addGestureRecognizer(gesture)
-        return button
-    }()
-
-    private lazy var lifeStyleButton: CategoryButton = {
-        let button = CategoryButton()
-        let category = Challenge.Category.lifeStyle
-        button.setImage(UIImage(named: category.symbol))
-        button.setTitle(category.title)
-        button.setTintColor(UIColor(named: category.color))
-
-        let gesture = CategoryButtonTapGesture(target: self, action: #selector(didTappedCategoryButton))
-        gesture.numberOfTapsRequired = 1
-        gesture.configureCategory(category: category)
-        self.isUserInteractionEnabled = true
-        button.addGestureRecognizer(gesture)
-        return button
-    }()
-
-    private lazy var financeButton: CategoryButton = {
-        let button = CategoryButton()
-        let category = Challenge.Category.finance
-        button.setImage(UIImage(systemName: category.symbol))
-        button.setTitle(category.title)
-        button.setTintColor(UIColor(named: category.color))
-
-        let gesture = CategoryButtonTapGesture(target: self, action: #selector(didTappedCategoryButton))
-        gesture.numberOfTapsRequired = 1
-        gesture.configureCategory(category: category)
-        self.isUserInteractionEnabled = true
-        button.addGestureRecognizer(gesture)
-        return button
-    }()
-
-    private lazy var hobbyButton: CategoryButton = {
-        let button = CategoryButton()
-        let category = Challenge.Category.hobby
-        button.setImage(UIImage(systemName: category.symbol))
-        button.setTitle(category.title)
-        button.setTintColor(UIColor(named: category.color))
-
-        let gesture = CategoryButtonTapGesture(target: self, action: #selector(didTappedCategoryButton))
-        gesture.numberOfTapsRequired = 1
-        gesture.configureCategory(category: category)
-        self.isUserInteractionEnabled = true
-        button.addGestureRecognizer(gesture)
-        return button
-    }()
-
-    private lazy var emotionManageButton: CategoryButton = {
-        let button = CategoryButton()
-        let category = Challenge.Category.emotionManage
-        button.setImage(UIImage(systemName: category.symbol))
-        button.setTitle(category.title)
-        button.setTintColor(UIColor(named: category.color))
-
-        let gesture = CategoryButtonTapGesture(target: self, action: #selector(didTappedCategoryButton))
-        gesture.numberOfTapsRequired = 1
-        gesture.configureCategory(category: category)
-        self.isUserInteractionEnabled = true
-        button.addGestureRecognizer(gesture)
-        return button
-    }()
-
-    private lazy var etcButton: CategoryButton = {
-        let button = CategoryButton()
-        let category = Challenge.Category.etc
-        button.setImage(UIImage(systemName: category.symbol))
-        button.setTitle(category.title)
-        button.setTintColor(UIColor(named: category.color))
-
-        let gesture = CategoryButtonTapGesture(target: self, action: #selector(didTappedCategoryButton))
-        gesture.numberOfTapsRequired = 1
-        gesture.configureCategory(category: category)
-        self.isUserInteractionEnabled = true
-        button.addGestureRecognizer(gesture)
-        return button
     }()
 
     @objc func didTappedCategoryButton(_ gesture: CategoryButtonTapGesture) {
@@ -160,20 +40,33 @@ final class ChallengeCategoryCell: UICollectionViewCell {
     func configureViews() {
         self.addSubview(yStackView)
         yStackView.snp.makeConstraints { make in
-            make.centerX.top.equalToSuperview()
+            make.leading.top.equalToSuperview()
+            make.trailing.equalToSuperview()
         }
 
         self.yStackView.addArrangedSubview(xStackView1)
-        xStackView1.addArrangedSubview(exerciseButton)
-        xStackView1.addArrangedSubview(studyButton)
-        xStackView1.addArrangedSubview(readButton)
-        xStackView1.addArrangedSubview(lifeStyleButton)
-
         self.yStackView.addArrangedSubview(xStackView2)
-        xStackView2.addArrangedSubview(financeButton)
-        xStackView2.addArrangedSubview(hobbyButton)
-        xStackView2.addArrangedSubview(emotionManageButton)
-        xStackView2.addArrangedSubview(etcButton)
+
+        for (index, category) in Challenge.Category.allCases.enumerated() {
+            let button = CategoryButton()
+            button.setImage(UIImage(named: category.symbol) != nil
+                            ? UIImage(named: category.symbol)
+                            : UIImage(systemName: category.symbol))
+            button.setTitle(category.title)
+            button.setTintColor(UIColor(named: category.color))
+
+            let gesture = CategoryButtonTapGesture(target: self, action: #selector(didTappedCategoryButton))
+            gesture.numberOfTapsRequired = 1
+            gesture.configureCategory(category: category)
+            self.isUserInteractionEnabled = true
+            button.addGestureRecognizer(gesture)
+
+            if index < 4 {
+                self.xStackView1.addArrangedSubview(button)
+            } else {
+                self.xStackView2.addArrangedSubview(button)
+            }
+        }
     }
 }
 

--- a/Routinus/Routinus/Presentation/Challenge/Layouts/CollectionViewLayouts.swift
+++ b/Routinus/Routinus/Presentation/Challenge/Layouts/CollectionViewLayouts.swift
@@ -9,6 +9,9 @@ import UIKit
 
 final class CollectionViewLayouts {
     private var recommendLayout: NSCollectionLayoutSection {
+        let smallWidth = UIScreen.main.bounds.width <= 350
+        let offset = smallWidth ? 15.0 : 25.0
+
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
@@ -17,12 +20,15 @@ final class CollectionViewLayouts {
 
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .groupPaging
-        section.contentInsets = .init(top: 30, leading: 25, bottom: 20, trailing: 25)
+        section.contentInsets = .init(top: 30, leading: offset, bottom: 20, trailing: offset)
         section.interGroupSpacing = 20
         return section
     }
 
     private var mainLayout: NSCollectionLayoutSection {
+        let smallWidth = UIScreen.main.bounds.width <= 350
+        let offset = smallWidth ? 15.0 : 25.0
+
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(200))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
@@ -36,7 +42,7 @@ final class CollectionViewLayouts {
                                                     alignment: .topLeading)]
 
         section.orthogonalScrollingBehavior = .none
-        section.contentInsets = .init(top: 0, leading: 25, bottom: 0, trailing: 25)
+        section.contentInsets = .init(top: 0, leading: offset, bottom: 0, trailing: offset)
         return section
     }
 

--- a/Routinus/Routinus/Presentation/Common/Cells/ChallengeCollectionViewCell.swift
+++ b/Routinus/Routinus/Presentation/Common/Cells/ChallengeCollectionViewCell.swift
@@ -58,7 +58,7 @@ extension ChallengeCollectionViewCell {
 
         self.addSubview(titleLabel)
         self.titleLabel.snp.makeConstraints { make in
-            make.leading.bottom.equalToSuperview()
+            make.leading.trailing.bottom.equalToSuperview()
             make.top.equalTo(imageView.snp.bottom).offset(10)
         }
     }

--- a/Routinus/Routinus/Presentation/Home/Cells/RoutineTableViewCell.swift
+++ b/Routinus/Routinus/Presentation/Home/Cells/RoutineTableViewCell.swift
@@ -37,7 +37,7 @@ final class RoutineTableViewCell: UITableViewCell {
         label.font = UIFont.systemFont(ofSize: 18, weight: .medium)
         return label
     }()
-    
+
     private lazy var leftArrow: UIImageView = {
         let imageConfig = UIImage.SymbolConfiguration(weight: .semibold)
         let image = UIImageView(image: UIImage(systemName: "chevron.left.2", withConfiguration: imageConfig))
@@ -74,11 +74,15 @@ final class RoutineTableViewCell: UITableViewCell {
 
 extension RoutineTableViewCell {
     private func configureViews() {
+        let smallWidth = UIScreen.main.bounds.width <= 350
+        let offset = smallWidth ? 15.0 : 20.0
+
         self.backgroundColor = .white
 
         self.contentView.addSubview(progressView)
         self.progressView.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview()
+            make.leading.equalToSuperview().offset(offset)
+            make.trailing.equalToSuperview().offset(-offset)
             make.height.equalToSuperview().offset(-10)
             make.centerY.equalToSuperview()
         }
@@ -86,7 +90,7 @@ extension RoutineTableViewCell {
         self.contentView.addSubview(categoryImageView)
         self.categoryImageView.snp.makeConstraints { make in
             make.width.height.equalTo(30)
-            make.leading.equalToSuperview().offset(20)
+            make.leading.equalToSuperview().offset(offset + 20)
             make.centerY.equalToSuperview()
         }
 
@@ -95,10 +99,10 @@ extension RoutineTableViewCell {
             make.leading.equalTo(self.categoryImageView.snp.trailing).offset(10)
             make.centerY.equalToSuperview()
         }
-        
+
         self.contentView.addSubview(leftArrow)
         self.leftArrow.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().offset(-20)
+            make.trailing.equalToSuperview().offset(-(20 + offset))
             make.centerY.equalToSuperview()
         }
     }

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -62,6 +62,9 @@ final class HomeViewController: UIViewController {
 
 extension HomeViewController {
     private func configureViews() {
+        let smallWidth = UIScreen.main.bounds.width <= 350
+        let offset = smallWidth ? 15.0 : 20.0
+
         self.view.backgroundColor = .white
         self.configureNavigationBar()
 
@@ -84,8 +87,8 @@ extension HomeViewController {
 
         self.contentView.addSubview(continuityView)
         self.continuityView.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(20)
-            make.trailing.equalToSuperview().offset(-20)
+            make.leading.equalToSuperview().offset(offset)
+            make.trailing.equalToSuperview().offset(-offset)
             make.top.equalTo(self.titleLabel.snp.bottom).offset(10)
             make.height.equalTo(80)
         }
@@ -99,8 +102,8 @@ extension HomeViewController {
 
         self.contentView.addSubview(calendarView)
         self.calendarView.snp.makeConstraints { make in
-            make.top.equalTo(todayRoutineView.snp.bottom).offset(20)
-            make.width.equalToSuperview().offset(-20)
+            make.top.equalTo(todayRoutineView.snp.bottom).offset(offset)
+            make.width.equalToSuperview().offset(-offset)
             make.centerX.equalToSuperview()
             make.height.equalTo(450)
         }
@@ -188,11 +191,8 @@ extension HomeViewController: UITableViewDelegate, UITableViewDataSource {
             self?.viewModel?.didTappedTodayRoutineAuth(index: indexPath.row)
         }
 
-        let largeConfig = UIImage.SymbolConfiguration(pointSize: 17, weight: .bold, scale: .large)
-        auth.image = UIImage(systemName: "camera", withConfiguration: largeConfig)?
-                        .withTintColor(.white).circularBackground(nil)
-        auth.backgroundColor = .systemBackground
-        auth.title = "auth"
+        auth.backgroundColor = .systemGreen
+        auth.title = "인증하기"
         return UISwipeActionsConfiguration(actions: [auth])
     }
 

--- a/Routinus/Routinus/Presentation/Home/Subviews/TodayRoutineView.swift
+++ b/Routinus/Routinus/Presentation/Home/Subviews/TodayRoutineView.swift
@@ -85,22 +85,25 @@ extension TodayRoutineView {
     }
 
     private func configureSubviews() {
+        let smallWidth = UIScreen.main.bounds.width <= 350
+        let offset = smallWidth ? 15.0 : 20.0
+
         addSubview(titleLabel)
         titleLabel.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(20)
+            make.leading.equalToSuperview().offset(offset)
             make.top.equalToSuperview()
         }
 
         addSubview(addButton)
         addButton.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().offset(-20)
+            make.trailing.equalToSuperview().offset(-offset)
             make.top.equalToSuperview()
         }
 
         addSubview(tableView)
         tableView.snp.makeConstraints { make in
             make.top.equalTo(titleLabel.snp.bottom).offset(10)
-            make.width.equalToSuperview().offset(-40)
+            make.width.equalToSuperview()
             make.centerX.equalToSuperview()
             make.height.equalTo(60)
         }

--- a/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
+++ b/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
@@ -57,6 +57,11 @@ final class ManageViewController: UIViewController {
         self.configureViewModel()
         self.configureCollectionView()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.viewModel?.didLoadedManageView()
+    }
 }
 
 extension ManageViewController {
@@ -80,6 +85,7 @@ extension ManageViewController {
                 guard let self = self else { return }
                 var challengeSnapshot = self.dataSource.snapshot(for: Section.challenge)
                 let challengeContents = challengeItem
+                challengeSnapshot.deleteAll()
                 challengeSnapshot.append(challengeContents)
                 self.dataSource.apply(challengeSnapshot, to: Section.challenge)
             })
@@ -104,6 +110,10 @@ extension ManageViewController {
 extension ManageViewController {
     @objc func didTouchAddButton() {
         self.viewModel?.didTappedAddButton()
+    }
+
+    func loadSearchView() {
+        self.viewModel?.didLoadedManageView()
     }
 }
 

--- a/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
+++ b/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
@@ -60,7 +60,7 @@ final class ManageViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.viewModel?.didLoadedManageView()
+        self.didLoadedSearchView()
     }
 }
 
@@ -112,7 +112,7 @@ extension ManageViewController {
         self.viewModel?.didTappedAddButton()
     }
 
-    func loadSearchView() {
+    func didLoadedSearchView() {
         self.viewModel?.didLoadedManageView()
     }
 }

--- a/Routinus/Routinus/Presentation/Manage/ManageViewModel.swift
+++ b/Routinus/Routinus/Presentation/Manage/ManageViewModel.swift
@@ -11,6 +11,7 @@ import Foundation
 protocol ManageViewModelInput {
     func didTappedAddButton()
     func didTappedChallenge(index: Int)
+    func didLoadedManageView()
 }
 
 protocol ManageViewModelOutput {
@@ -33,7 +34,6 @@ class ManageViewModel: ManageViewModelIO {
 
     init(challengeFetchUsecase: ChallengeFetchableUsecase) {
         self.challengeFetchUsecase = challengeFetchUsecase
-        self.fetchChallenges()
     }
 }
 
@@ -45,6 +45,10 @@ extension ManageViewModel {
     func didTappedChallenge(index: Int) {
         let challengeID = self.challenges.value[index].challengeID
         challengeTap.send(challengeID)
+    }
+
+    func didLoadedManageView() {
+        fetchChallenges()
     }
 }
 

--- a/Routinus/Routinus/Presentation/Search/SearchViewController.swift
+++ b/Routinus/Routinus/Presentation/Search/SearchViewController.swift
@@ -74,7 +74,7 @@ final class SearchViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        loadSearchView()
+        didLoadedSearchView()
     }
 
 }
@@ -218,7 +218,7 @@ extension SearchViewController: UISearchBarDelegate {
         self.searchBarView.hideKeyboard()
     }
 
-    func loadSearchView() {
-        self.viewModel?.didEnterSearchView()
+    func didLoadedSearchView() {
+        self.viewModel?.didLoadedSearchView()
     }
 }

--- a/Routinus/Routinus/Presentation/Search/SearchViewController.swift
+++ b/Routinus/Routinus/Presentation/Search/SearchViewController.swift
@@ -72,6 +72,11 @@ final class SearchViewController: UIViewController {
         self.configureViewModel()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        loadSearchView()
+    }
+
 }
 
 extension SearchViewController {
@@ -211,5 +216,9 @@ extension SearchViewController: UISearchBarDelegate {
 
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         self.searchBarView.hideKeyboard()
+    }
+
+    func loadSearchView() {
+        self.viewModel?.didEnterSearchView()
     }
 }

--- a/Routinus/Routinus/Presentation/Search/SearchViewModel.swift
+++ b/Routinus/Routinus/Presentation/Search/SearchViewModel.swift
@@ -11,6 +11,7 @@ import Foundation
 protocol SearchViewModelInput {
     func didChangedSearchText(_ keyword: String)
     func didTappedChallenge(index: Int)
+    func didEnterSearchView()
     func imageData(from directory: String,
                    filename: String,
                    completion: ((Data?) -> Void)?)
@@ -44,7 +45,6 @@ final class SearchViewModel: SearchViewModelIO {
         self.imageFetchUsecase = imageFetchUsecase
         self.challengeFetchUsecase = challengeFetchUsecase
         self.fetchPopularKeywords()
-        self.fetchChallenges()
     }
 }
 
@@ -64,6 +64,10 @@ extension SearchViewModel {
     func didTappedChallenge(index: Int) {
         let challengeID = self.challenges.value[index].challengeID
         challengeTap.send(challengeID)
+    }
+
+    func didEnterSearchView() {
+        self.fetchChallenges()
     }
 
     func imageData(from directory: String,

--- a/Routinus/Routinus/Presentation/Search/SearchViewModel.swift
+++ b/Routinus/Routinus/Presentation/Search/SearchViewModel.swift
@@ -11,7 +11,7 @@ import Foundation
 protocol SearchViewModelInput {
     func didChangedSearchText(_ keyword: String)
     func didTappedChallenge(index: Int)
-    func didEnterSearchView()
+    func didLoadedSearchView()
     func imageData(from directory: String,
                    filename: String,
                    completion: ((Data?) -> Void)?)
@@ -66,7 +66,7 @@ extension SearchViewModel {
         challengeTap.send(challengeID)
     }
 
-    func didEnterSearchView() {
+    func didLoadedSearchView() {
         self.fetchChallenges()
     }
 


### PR DESCRIPTION
## 관련 issue

close #204 
close #206 

## 작업 내용

- [x] 멘토링 UI 관련 사항 수정
- iPodTouch 7세대 대응
- 오늘 루틴 좌우측 잘려보이던 사항 수정
- [x] 검색화면 fetch 로직 수정
- viewWillAppear에서 새로 fetch 해오도록 수정했습니다

## 기타 사항

- search까지만 보고 다른 브랜치 인줄 알았는데 같은 브랜치에서 작업해서.... 두 작업이 묶였습니다 죄송합니다 ㅠ
- 뷰 만들일이 얼마 안남았지만
 ```
let smallWidth = UIScreen.main.bounds.width <= 350
let offset = smallWidth ? 15.0 : 20
```
이걸로 작은 화면 대응 하시면 좋을 것 같아요~~