### PR TITLE
[인증 화면] 인증화면 View 구성 및 challenge_auth database 구성

### DIFF
--- a/Routinus/Routinus.xcodeproj/project.pbxproj
+++ b/Routinus/Routinus.xcodeproj/project.pbxproj
@@ -71,6 +71,10 @@
 		E901EFE02744CC4F00B14847 /* AchievementFetchUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E901EFDF2744CC4F00B14847 /* AchievementFetchUsecase.swift */; };
 		E901EFE22744CC6E00B14847 /* AchievementRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E901EFE12744CC6E00B14847 /* AchievementRepository.swift */; };
 		E901EFE42744D41600B14847 /* ImageSaveUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E901EFE32744D41600B14847 /* ImageSaveUsecase.swift */; };
+		E901EFE827453F1100B14847 /* ChallengeAuthRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E901EFE727453F1100B14847 /* ChallengeAuthRepository.swift */; };
+		E901EFEA27453F2000B14847 /* ChallengeAuthCreateUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E901EFE927453F2000B14847 /* ChallengeAuthCreateUsecase.swift */; };
+		E901EFEC27453F6600B14847 /* ChallengeAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = E901EFEB27453F6600B14847 /* ChallengeAuth.swift */; };
+		E901EFEE2745400900B14847 /* ChallengeAuthDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E901EFED2745400900B14847 /* ChallengeAuthDTO.swift */; };
 		E91C1916273CACDD00D11127 /* PopularKeyword.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91C1915273CACDD00D11127 /* PopularKeyword.swift */; };
 		E937044227434D4700D82B1D /* AuthMethodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E937044127434D4700D82B1D /* AuthMethodView.swift */; };
 		E937044427434D6300D82B1D /* PreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E937044327434D6300D82B1D /* PreviewView.swift */; };
@@ -219,6 +223,10 @@
 		E901EFDF2744CC4F00B14847 /* AchievementFetchUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementFetchUsecase.swift; sourceTree = "<group>"; };
 		E901EFE12744CC6E00B14847 /* AchievementRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRepository.swift; sourceTree = "<group>"; };
 		E901EFE32744D41600B14847 /* ImageSaveUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSaveUsecase.swift; sourceTree = "<group>"; };
+		E901EFE727453F1100B14847 /* ChallengeAuthRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeAuthRepository.swift; sourceTree = "<group>"; };
+		E901EFE927453F2000B14847 /* ChallengeAuthCreateUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeAuthCreateUsecase.swift; sourceTree = "<group>"; };
+		E901EFEB27453F6600B14847 /* ChallengeAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeAuth.swift; sourceTree = "<group>"; };
+		E901EFED2745400900B14847 /* ChallengeAuthDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeAuthDTO.swift; sourceTree = "<group>"; };
 		E91C1915273CACDD00D11127 /* PopularKeyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularKeyword.swift; sourceTree = "<group>"; };
 		E937044127434D4700D82B1D /* AuthMethodView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthMethodView.swift; sourceTree = "<group>"; };
 		E937044327434D6300D82B1D /* PreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewView.swift; sourceTree = "<group>"; };
@@ -342,6 +350,7 @@
 				E901EFDB2744CAF900B14847 /* TodayRoutineRepository.swift */,
 				E901EFE12744CC6E00B14847 /* AchievementRepository.swift */,
 				E901EFD32744BD3400B14847 /* ImageRepository.swift */,
+				E901EFE727453F1100B14847 /* ChallengeAuthRepository.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -376,6 +385,7 @@
 				441CEDF42739029C006C261F /* AchievementDTO.swift */,
 				E9D0CAE7273978C600F66390 /* ChallengeDTO.swift */,
 				446A07152740ECE6009F8D98 /* ParticipationDTO.swift */,
+				E901EFED2745400900B14847 /* ChallengeAuthDTO.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -552,6 +562,7 @@
 				E975390527325538004358C5 /* Achievement.swift */,
 				E9B1298127336EE50072D254 /* TodayRoutine.swift */,
 				E94B49752739118B00708D7B /* Challenge.swift */,
+				E901EFEB27453F6600B14847 /* ChallengeAuth.swift */,
 				E91C1915273CACDD00D11127 /* PopularKeyword.swift */,
 				0DE03397274329B90026F502 /* Calendar.swift */,
 			);
@@ -570,6 +581,7 @@
 				E901EFDF2744CC4F00B14847 /* AchievementFetchUsecase.swift */,
 				E901EFD52744BDBD00B14847 /* ImageFetchUsecase.swift */,
 				E901EFE32744D41600B14847 /* ImageSaveUsecase.swift */,
+				E901EFE927453F2000B14847 /* ChallengeAuthCreateUsecase.swift */,
 			);
 			path = Usecase;
 			sourceTree = "<group>";
@@ -1001,6 +1013,7 @@
 				446A071B2740F629009F8D98 /* RoutinusQuery.swift in Sources */,
 				E9D0CAE8273978C600F66390 /* ChallengeDTO.swift in Sources */,
 				446A07162740ECE6009F8D98 /* ParticipationDTO.swift in Sources */,
+				E901EFEE2745400900B14847 /* ChallengeAuthDTO.swift in Sources */,
 				441CEDF327390296006C261F /* TodayRoutineDTO.swift in Sources */,
 				441CEDFD27390378006C261F /* RoutinusDatabase.swift in Sources */,
 			);
@@ -1039,6 +1052,7 @@
 				E9797CA02730FF9C00A14A0F /* RoutinusCoordinator.swift in Sources */,
 				441CEE19273A33DB006C261F /* CreateWeekView.swift in Sources */,
 				E901EFDE2744CBDE00B14847 /* UserFetchUsecase.swift in Sources */,
+				E901EFE827453F1100B14847 /* ChallengeAuthRepository.swift in Sources */,
 				E9797CA02730FF9C00A14A0F /* RoutinusCoordinator.swift in Sources */,
 				1497CF442738FFA600296F9E /* RoutinusRepository.swift in Sources */,
 				441CEDD327378EBF006C261F /* TodayRoutineView.swift in Sources */,
@@ -1046,6 +1060,7 @@
 				E975390627325538004358C5 /* Achievement.swift in Sources */,
 				441CEE1B273A33FE006C261F /* CreateAuthMethodView.swift in Sources */,
 				E9797CBD27310E1900A14A0F /* HomeCoordinator.swift in Sources */,
+				E901EFEC27453F6600B14847 /* ChallengeAuth.swift in Sources */,
 				14572CED273BF644007E6ECE /* CreateCoordinator.swift in Sources */,
 				E901EFE02744CC4F00B14847 /* AchievementFetchUsecase.swift in Sources */,
 				E901EFD82744C9E300B14847 /* UserRepository.swift in Sources */,
@@ -1085,6 +1100,7 @@
 				0DBBAA3D27341C3600B32EB5 /* ChallengeCategoryCell.swift in Sources */,
 				E937044227434D4700D82B1D /* AuthMethodView.swift in Sources */,
 				0DC38F44273A3B9900331C25 /* SearchCoordinator.swift in Sources */,
+				E901EFEA27453F2000B14847 /* ChallengeAuthCreateUsecase.swift in Sources */,
 				E93704492743B2F800D82B1D /* AuthViewModel.swift in Sources */,
 				E9797CA22730FFAD00A14A0F /* TabBarCoordinator.swift in Sources */,
 				E9493DC8273A70280095CF6D /* SearchPopularKeywordCell.swift in Sources */,

--- a/Routinus/Routinus/Application/Coordinator/AuthCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/AuthCoordinator.swift
@@ -22,10 +22,12 @@ final class AuthCoordinator: RoutinusCoordinator {
         let challengeFetchUsecase = ChallengeFetchUsecase(repository: repository)
         let imageFetchUsecase = ImageFetchUsecase(repository: repository)
         let imageSaveUsecase = ImageSaveUsecase(repository: repository)
+        let challengeAuthCreateUsecase = ChallengeAuthCreateUsecase(repository: repository)
         let authViewModel = AuthViewModel(challengeID: challengeID,
                                           challengeFetchUsecase: challengeFetchUsecase,
                                           imageFetchUsecase: imageFetchUsecase,
-                                          imageSaveUsecase: imageSaveUsecase)
+                                          imageSaveUsecase: imageSaveUsecase,
+                                          challengeAuthCreateUsecase: challengeAuthCreateUsecase)
         let authViewController = AuthViewController(viewModel: authViewModel)
         authViewController.hidesBottomBarWhenPushed = true
         self.navigationController.pushViewController(authViewController, animated: true)

--- a/Routinus/Routinus/Application/Coordinator/AuthCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/AuthCoordinator.swift
@@ -20,8 +20,12 @@ final class AuthCoordinator: RoutinusCoordinator {
     func start() {
         let repository = RoutinusRepository()
         let challengeFetchUsecase = ChallengeFetchUsecase(repository: repository)
+        let imageFetchUsecase = ImageFetchUsecase(repository: repository)
+        let imageSaveUsecase = ImageSaveUsecase(repository: repository)
         let authViewModel = AuthViewModel(challengeID: challengeID,
-                                          challengeFetchUsecase: challengeFetchUsecase)
+                                          challengeFetchUsecase: challengeFetchUsecase,
+                                          imageFetchUsecase: imageFetchUsecase,
+                                          imageSaveUsecase: imageSaveUsecase)
         let authViewController = AuthViewController(viewModel: authViewModel)
         authViewController.hidesBottomBarWhenPushed = true
         self.navigationController.pushViewController(authViewController, animated: true)

--- a/Routinus/Routinus/Data/ChallengeAuthRepository.swift
+++ b/Routinus/Routinus/Data/ChallengeAuthRepository.swift
@@ -20,8 +20,8 @@ extension RoutinusRepository: ChallengeAuthRepository {
     func save(challengeAuth: ChallengeAuth,
               userAuthImageURL: String,
               userAuthThumbnailImageURL: String) {
-        guard let date = challengeAuth.date?.toString(),
-              let time = challengeAuth.time?.toStringHourMinute() else { return }
+        guard let date = challengeAuth.date?.toDateString(),
+              let time = challengeAuth.time?.toTimeString() else { return }
 
         let challengeAuthDTO = ChallengeAuthDTO(challengeID: challengeAuth.challengeID,
                                                 userID: challengeAuth.userID,

--- a/Routinus/Routinus/Data/ChallengeAuthRepository.swift
+++ b/Routinus/Routinus/Data/ChallengeAuthRepository.swift
@@ -1,0 +1,37 @@
+//
+//  ChallengeAuthRepository.swift
+//  Routinus
+//
+//  Created by 박상우 on 2021/11/17.
+//
+
+import Foundation
+
+import RoutinusDatabase
+import RoutinusImageManager
+
+protocol ChallengeAuthRepository {
+    func save(challengeAuth: ChallengeAuth,
+              userAuthImageURL: String,
+              userAuthThumbnailImageURL: String)
+}
+
+extension RoutinusRepository: ChallengeAuthRepository {
+    func save(challengeAuth: ChallengeAuth,
+              userAuthImageURL: String,
+              userAuthThumbnailImageURL: String) {
+        guard let date = challengeAuth.date?.toString(),
+              let time = challengeAuth.time?.toStringHourMinute() else { return }
+
+        let challengeAuthDTO = ChallengeAuthDTO(challengeID: challengeAuth.challengeID,
+                                                userID: challengeAuth.userID,
+                                                date: date,
+                                                time: time)
+        
+        RoutinusDatabase.createChallengeAuth(challengeAuth: challengeAuthDTO,
+                                             userAuthImageURL: userAuthImageURL,
+                                             userAuthThumbnailImageURL: userAuthThumbnailImageURL) {
+            RoutinusImageManager.removeTempCachedImages()
+        }
+    }
+}

--- a/Routinus/Routinus/Data/ChallengeRepository.swift
+++ b/Routinus/Routinus/Data/ChallengeRepository.swift
@@ -80,8 +80,8 @@ extension RoutinusRepository: ChallengeRepository {
               thumbnailImageURL: String,
               authExampleImageURL: String,
               authExampleThumbnailImageURL: String) {
-        guard let startDate = challenge.startDate?.toString(),
-              let endDate = challenge.endDate?.toString() else { return }
+        guard let startDate = challenge.startDate?.toDateString(),
+              let endDate = challenge.endDate?.toDateString() else { return }
 
         let challengeDTO = ChallengeDTO(id: challenge.challengeID,
                                         title: challenge.title,
@@ -108,8 +108,8 @@ extension RoutinusRepository: ChallengeRepository {
                 thumbnailImageURL: String,
                 authExampleImageURL: String,
                 authExampleThumbnailImageURL: String) async {
-        guard let startDate = challenge.startDate?.toString(),
-              let endDate = challenge.endDate?.toString() else { return }
+        guard let startDate = challenge.startDate?.toDateString(),
+              let endDate = challenge.endDate?.toDateString() else { return }
         let challengeDTO = ChallengeDTO(id: challenge.challengeID,
                                         title: challenge.title,
                                         authMethod: challenge.authMethod,

--- a/Routinus/Routinus/Domain/Entity/ChallengeAuth.swift
+++ b/Routinus/Routinus/Domain/Entity/ChallengeAuth.swift
@@ -31,6 +31,6 @@ struct ChallengeAuth {
         self.challengeID = document?.challengeID.stringValue ?? ""
         self.userID = document?.userID.stringValue ?? ""
         self.date = Date(dateString: document?.date.stringValue ?? "")
-        self.time = Date(hourMinuteString: document?.time.stringValue ?? "")
+        self.time = Date(timeString: document?.time.stringValue ?? "")
     }
 }

--- a/Routinus/Routinus/Domain/Entity/ChallengeAuth.swift
+++ b/Routinus/Routinus/Domain/Entity/ChallengeAuth.swift
@@ -1,0 +1,36 @@
+//
+//  ChallengeAuth.swift
+//  Routinus
+//
+//  Created by 박상우 on 2021/11/17.
+//
+
+import Foundation
+
+import RoutinusDatabase
+
+struct ChallengeAuth {
+    var challengeID: String
+    var userID: String
+    var date: Date?
+    var time: Date?
+
+    init(challengeID: String,
+         userID: String,
+         date: Date?,
+         time: Date?) {
+        self.challengeID = challengeID
+        self.userID = userID
+        self.date = date
+        self.time = time
+    }
+
+    init(challengeAuthDTO: ChallengeAuthDTO) {
+        let document = challengeAuthDTO.document?.fields
+
+        self.challengeID = document?.challengeID.stringValue ?? ""
+        self.userID = document?.userID.stringValue ?? ""
+        self.date = Date(dateString: document?.date.stringValue ?? "")
+        self.time = Date(hourMinuteString: document?.time.stringValue ?? "")
+    }
+}

--- a/Routinus/Routinus/Domain/Usecase/ChallengeAuthCreateUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/ChallengeAuthCreateUsecase.swift
@@ -1,0 +1,39 @@
+//
+//  ChallengeAuthCreateUsecase.swift
+//  Routinus
+//
+//  Created by 박상우 on 2021/11/17.
+//
+
+import Foundation
+
+protocol ChallengeAuthCreatableUsecase {
+    func createChallengeAuth(challengeID: String,
+                             userAuthImageURL: String,
+                             userAuthThumbnailImageURL: String)
+}
+
+struct ChallengeAuthCreateUsecase: ChallengeAuthCreatableUsecase {
+    var repository: ChallengeAuthRepository
+
+    init(repository: ChallengeAuthRepository) {
+        self.repository = repository
+    }
+
+    func createChallengeAuth(challengeID: String,
+                             userAuthImageURL: String,
+                             userAuthThumbnailImageURL: String) {
+        guard let userID = RoutinusRepository.userID() else { return }
+
+        let challengeAuth = ChallengeAuth(challengeID: challengeID,
+                                          userID: userID,
+                                          date: Date.now,
+                                          time: Date.now)
+
+        repository.save(challengeAuth: challengeAuth,
+                        userAuthImageURL: userAuthImageURL,
+                        userAuthThumbnailImageURL: userAuthThumbnailImageURL)
+    }
+    
+    
+}

--- a/Routinus/Routinus/Extensions/Date+Extensions.swift
+++ b/Routinus/Routinus/Extensions/Date+Extensions.swift
@@ -18,6 +18,16 @@ extension Date {
         self.init(timeInterval: 0, since: date)
     }
 
+    init(hourMinuteString: String) {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HHmm"
+        guard let date = formatter.date(from: hourMinuteString) else {
+            self.init(timeInterval: 0, since: Date())
+            return
+        }
+        self.init(timeInterval: 0, since: date)
+    }
+
     public var year: Int {
         return Calendar.current.component(.year, from: self)
     }
@@ -55,6 +65,12 @@ extension Date {
     func toString() -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyyMMdd"
+        return dateFormatter.string(from: self)
+    }
+
+    func toStringHourMinute() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "HHmm"
         return dateFormatter.string(from: self)
     }
 

--- a/Routinus/Routinus/Extensions/Date+Extensions.swift
+++ b/Routinus/Routinus/Extensions/Date+Extensions.swift
@@ -18,10 +18,10 @@ extension Date {
         self.init(timeInterval: 0, since: date)
     }
 
-    init(hourMinuteString: String) {
+    init(timeString: String) {
         let formatter = DateFormatter()
         formatter.dateFormat = "HHmm"
-        guard let date = formatter.date(from: hourMinuteString) else {
+        guard let date = formatter.date(from: timeString) else {
             self.init(timeInterval: 0, since: Date())
             return
         }
@@ -62,19 +62,19 @@ extension Date {
         return "\(year)\(month)"
     }
 
-    func toString() -> String {
+    func toDateString() -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyyMMdd"
         return dateFormatter.string(from: self)
     }
 
-    func toStringHourMinute() -> String {
+    func toTimeString() -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "HHmm"
         return dateFormatter.string(from: self)
     }
 
-    func toExtendedString() -> String {
+    func toDateWithWeekdayString() -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy.MM.dd(E)"
         return dateFormatter.string(from: self)

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -109,11 +109,20 @@ extension AuthViewController {
                 })
             })
             .store(in: &cancellables)
+
+        self.viewModel?.authButtonState
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] isEnabled in
+                guard let self = self else { return }
+                self.authButton.configureEnabled(isEnabled: isEnabled)
+            })
+            .store(in: &cancellables)
     }
 
     private func configureDelegates() {
         self.imagePicker.delegate = self
         self.previewView.delegate = self
+        self.authButton.delegate = self
     }
 }
 
@@ -121,6 +130,13 @@ extension AuthViewController: PreviewViewDelegate {
     func didTappedPreviewView() {
         self.imagePicker.sourceType = .camera
         self.present(self.imagePicker, animated: true, completion: nil)
+    }
+}
+
+extension AuthViewController: AuthButtonDelegate {
+    func didTappedAuthButton() {
+        self.viewModel?.didTappedAuthButton()
+        self.navigationController?.popViewController(animated: true) 
     }
 }
 

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -139,6 +139,8 @@ extension AuthViewController: UIImagePickerControllerDelegate, UINavigationContr
             let thumbnailImageURL = viewModel?.saveImage(to: "temp",
                                                          filename: "thumbnail_userAuth",
                                                          data: thumbnailImage.jpegData(compressionQuality: 0.9))
+            self.viewModel?.update(userAuthImageURL: mainImageURL)
+            self.viewModel?.update(userAuthThumbnailImageURL: thumbnailImageURL)
             previewView.setImage(thumbnailImage)
         }
         dismiss(animated: true, completion: nil)

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -18,6 +18,7 @@ final class AuthViewController: UIViewController {
     private lazy var authMethodView = AuthMethodView()
     private lazy var previewView = PreviewView()
     private lazy var authButton = AuthButton()
+    private var imagePicker = UIImagePickerController()
 
     init() {
         super.init(nibName: nil, bundle: nil)
@@ -31,6 +32,7 @@ final class AuthViewController: UIViewController {
         super.viewDidLoad()
 
         configureViews()
+        configureDelegates()
     }
 }
 
@@ -70,5 +72,40 @@ extension AuthViewController {
 
     private func configureNavigationBar() {
         self.navigationItem.largeTitleDisplayMode = .never
+    }
+    
+    private func configureDelegates() {
+        self.imagePicker.delegate = self
+        self.previewView.delegate = self
+    }
+}
+
+extension AuthViewController: PreviewViewDelegate {
+    func didTappedAuthButton() {
+        self.imagePicker.sourceType = .camera
+        self.present(self.imagePicker, animated: true, completion: nil)
+    }
+}
+
+extension AuthViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    typealias InfoKey = UIImagePickerController.InfoKey
+
+    func imagePickerController(_ picker: UIImagePickerController,
+                               didFinishPickingMediaWithInfo info: [InfoKey: Any]) {
+        if let originalImage = info[InfoKey.originalImage] as? UIImage {
+            let mainImage = originalImage.resizedImage(.main)
+            let thumbnailImage = originalImage.resizedImage(.thumbnail)
+            
+//            let mainImageURL = viewModel?.saveImage(to: "temp",
+//                                                    filename: "auth",
+//                                                    data: mainImage.jpegData(compressionQuality: 0.9))
+//            let thumbnailImageURL = viewModel?.saveImage(to: "temp",
+//                                                         filename: "thumbnail_auth",
+//                                                         data: thumbnailImage.jpegData(compressionQuality: 0.9))
+//            viewModel?.update(authExampleImageURL: mainImageURL)
+//            viewModel?.update(authExampleThumbnailImageURL: thumbnailImageURL)
+            previewView.setImage(thumbnailImage)
+        }
+        dismiss(animated: true, completion: nil)
     }
 }

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -16,6 +16,11 @@ final class AuthViewController: UIViewController {
         stackView.spacing = 30
         return stackView
     }()
+    private lazy var authView: UIView = {
+        var view = UIView()
+        view.backgroundColor = .white
+        return view
+    }()
     private lazy var authMethodView = AuthMethodView()
     private lazy var previewView = PreviewView()
     private lazy var authButton = AuthButton()
@@ -50,9 +55,23 @@ extension AuthViewController {
         self.view.addSubview(scrollView)
         self.scrollView.translatesAutoresizingMaskIntoConstraints = false
         self.scrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor).isActive = true
-        self.scrollView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor).isActive = true
         self.scrollView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor).isActive = true
         self.scrollView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+        
+        self.view.addSubview(authView)
+        self.authView.translatesAutoresizingMaskIntoConstraints = false
+        self.authView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        self.authView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        self.authView.topAnchor.constraint(equalTo: scrollView.bottomAnchor).isActive = true
+        self.authView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        self.authView.heightAnchor.constraint(equalToConstant: 100).isActive = true
+
+        self.authView.addSubview(authButton)
+        self.authButton.translatesAutoresizingMaskIntoConstraints = false
+        self.authButton.topAnchor.constraint(equalTo: authView.topAnchor, constant: 20).isActive = true
+        self.authButton.bottomAnchor.constraint(equalTo: authView.bottomAnchor, constant: -20).isActive = true
+        self.authButton.leadingAnchor.constraint(equalTo: authView.leadingAnchor, constant: 20).isActive = true
+        self.authButton.trailingAnchor.constraint(equalTo: authView.trailingAnchor, constant: -20).isActive = true
 
         self.scrollView.addSubview(stackView)
         self.stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -67,11 +86,6 @@ extension AuthViewController {
         self.stackView.addArrangedSubview(previewView)
         self.previewView.translatesAutoresizingMaskIntoConstraints = false
         self.previewView.heightAnchor.constraint(equalTo: self.previewView.widthAnchor, multiplier: 1).isActive = true
-
-        self.stackView.addArrangedSubview(authButton)
-        self.authButton.translatesAutoresizingMaskIntoConstraints = false
-        self.authButton.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
-        self.authButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
     }
 
     private func configureNavigationBar() {

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -15,6 +15,11 @@ final class AuthViewController: UIViewController {
         stackView.spacing = 30
         return stackView
     }()
+    private lazy var authView: UIView = {
+        var view = UIView()
+        view.backgroundColor = .white
+        return view
+    }()
     private lazy var authMethodView = AuthMethodView()
     private lazy var previewView = PreviewView()
     private lazy var authButton = AuthButton()
@@ -44,9 +49,23 @@ extension AuthViewController {
         self.view.addSubview(scrollView)
         self.scrollView.translatesAutoresizingMaskIntoConstraints = false
         self.scrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor).isActive = true
-        self.scrollView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor).isActive = true
         self.scrollView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor).isActive = true
         self.scrollView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+        
+        self.view.addSubview(authView)
+        self.authView.translatesAutoresizingMaskIntoConstraints = false
+        self.authView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        self.authView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        self.authView.topAnchor.constraint(equalTo: scrollView.bottomAnchor).isActive = true
+        self.authView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        self.authView.heightAnchor.constraint(equalToConstant: 100).isActive = true
+
+        self.authView.addSubview(authButton)
+        self.authButton.translatesAutoresizingMaskIntoConstraints = false
+        self.authButton.topAnchor.constraint(equalTo: authView.topAnchor, constant: 20).isActive = true
+        self.authButton.bottomAnchor.constraint(equalTo: authView.bottomAnchor, constant: -20).isActive = true
+        self.authButton.leadingAnchor.constraint(equalTo: authView.leadingAnchor, constant: 20).isActive = true
+        self.authButton.trailingAnchor.constraint(equalTo: authView.trailingAnchor, constant: -20).isActive = true
 
         self.scrollView.addSubview(stackView)
         self.stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -61,11 +80,6 @@ extension AuthViewController {
         self.stackView.addArrangedSubview(previewView)
         self.previewView.translatesAutoresizingMaskIntoConstraints = false
         self.previewView.heightAnchor.constraint(equalTo: self.previewView.widthAnchor, multiplier: 1).isActive = true
-
-        self.stackView.addArrangedSubview(authButton)
-        self.authButton.translatesAutoresizingMaskIntoConstraints = false
-        self.authButton.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
-        self.authButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
     }
 
     private func configureNavigationBar() {

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -109,7 +109,7 @@ extension AuthViewController {
 }
 
 extension AuthViewController: PreviewViewDelegate {
-    func didTappedPreview() {
+    func didTappedPreviewView() {
         self.imagePicker.sourceType = .camera
         self.present(self.imagePicker, animated: true, completion: nil)
     }

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -95,7 +95,7 @@ extension AuthViewController {
 }
 
 extension AuthViewController: PreviewViewDelegate {
-    func didTappedAuthButton() {
+    func didTappedPreview() {
         self.imagePicker.sourceType = .camera
         self.present(self.imagePicker, animated: true, completion: nil)
     }

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -22,6 +22,7 @@ final class AuthViewController: UIViewController {
     
     private var viewModel: AuthViewModelIO?
     private var cancellables = Set<AnyCancellable>()
+    private var imagePicker = UIImagePickerController()
 
     init(viewModel: AuthViewModelIO) {
         self.viewModel = viewModel
@@ -37,6 +38,7 @@ final class AuthViewController: UIViewController {
 
         configureViews()
         configureViewModel()
+        configureDelegates()
     }
 }
 
@@ -86,5 +88,40 @@ extension AuthViewController {
                 self.navigationItem.title = challenge.title
             })
             .store(in: &cancellables)
+    }
+
+    private func configureDelegates() {
+        self.imagePicker.delegate = self
+        self.previewView.delegate = self
+    }
+}
+
+extension AuthViewController: PreviewViewDelegate {
+    func didTappedAuthButton() {
+        self.imagePicker.sourceType = .camera
+        self.present(self.imagePicker, animated: true, completion: nil)
+    }
+}
+
+extension AuthViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    typealias InfoKey = UIImagePickerController.InfoKey
+
+    func imagePickerController(_ picker: UIImagePickerController,
+                               didFinishPickingMediaWithInfo info: [InfoKey: Any]) {
+        if let originalImage = info[InfoKey.originalImage] as? UIImage {
+            let mainImage = originalImage.resizedImage(.main)
+            let thumbnailImage = originalImage.resizedImage(.thumbnail)
+            
+//            let mainImageURL = viewModel?.saveImage(to: "temp",
+//                                                    filename: "auth",
+//                                                    data: mainImage.jpegData(compressionQuality: 0.9))
+//            let thumbnailImageURL = viewModel?.saveImage(to: "temp",
+//                                                         filename: "thumbnail_auth",
+//                                                         data: thumbnailImage.jpegData(compressionQuality: 0.9))
+//            viewModel?.update(authExampleImageURL: mainImageURL)
+//            viewModel?.update(authExampleThumbnailImageURL: thumbnailImageURL)
+            previewView.setImage(thumbnailImage)
+        }
+        dismiss(animated: true, completion: nil)
     }
 }

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -96,8 +96,17 @@ extension AuthViewController {
         self.viewModel?.challenge
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] challenge in
-                guard let self = self else { return }
+                guard let self = self,
+                      let challenge = challenge else { return }
                 self.navigationItem.title = challenge.title
+                self.authMethodView.configureMethodLabel(introduction: challenge.introduction)
+                self.viewModel?.imageData(from: challenge.challengeID,
+                                          filename: "thumbnail_image",
+                                          completion: { data in
+                    DispatchQueue.main.async {
+                        self.authMethodView.configureMethodImage(data: data)
+                    }
+                })
             })
             .store(in: &cancellables)
     }
@@ -123,15 +132,13 @@ extension AuthViewController: UIImagePickerControllerDelegate, UINavigationContr
         if let originalImage = info[InfoKey.originalImage] as? UIImage {
             let mainImage = originalImage.resizedImage(.main)
             let thumbnailImage = originalImage.resizedImage(.thumbnail)
-            
-//            let mainImageURL = viewModel?.saveImage(to: "temp",
-//                                                    filename: "auth",
-//                                                    data: mainImage.jpegData(compressionQuality: 0.9))
-//            let thumbnailImageURL = viewModel?.saveImage(to: "temp",
-//                                                         filename: "thumbnail_auth",
-//                                                         data: thumbnailImage.jpegData(compressionQuality: 0.9))
-//            viewModel?.update(authExampleImageURL: mainImageURL)
-//            viewModel?.update(authExampleThumbnailImageURL: thumbnailImageURL)
+
+            let mainImageURL = viewModel?.saveImage(to: "temp",
+                                                    filename: "userAuth",
+                                                    data: mainImage.jpegData(compressionQuality: 0.9))
+            let thumbnailImageURL = viewModel?.saveImage(to: "temp",
+                                                         filename: "thumbnail_userAuth",
+                                                         data: thumbnailImage.jpegData(compressionQuality: 0.9))
             previewView.setImage(thumbnailImage)
         }
         dismiss(animated: true, completion: nil)

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -79,7 +79,7 @@ extension AuthViewController {
 }
 
 extension AuthViewController: PreviewViewDelegate {
-    func didTappedAuthButton() {
+    func didTappedPreview() {
         self.imagePicker.sourceType = .camera
         self.present(self.imagePicker, animated: true, completion: nil)
     }

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -58,13 +58,11 @@ extension AuthViewController {
         self.stackView.translatesAutoresizingMaskIntoConstraints = false
         self.stackView.topAnchor.constraint(equalTo: self.scrollView.topAnchor).isActive = true
         self.stackView.bottomAnchor.constraint(equalTo: self.scrollView.bottomAnchor, constant: -20).isActive = true
-        self.stackView.leadingAnchor.constraint(equalTo: self.scrollView.leadingAnchor, constant: 20).isActive = true
-        self.stackView.trailingAnchor.constraint(equalTo: self.scrollView.trailingAnchor, constant: -20).isActive = true
+        self.stackView.leadingAnchor.constraint(equalTo: self.scrollView.leadingAnchor).isActive = true
+        self.stackView.trailingAnchor.constraint(equalTo: self.scrollView.trailingAnchor).isActive = true
         self.stackView.centerXAnchor.constraint(equalTo: self.scrollView.centerXAnchor).isActive = true
 
         self.stackView.addArrangedSubview(authMethodView)
-        self.authMethodView.translatesAutoresizingMaskIntoConstraints = false
-        self.authMethodView.heightAnchor.constraint(equalToConstant: 240).isActive = true
 
         self.stackView.addArrangedSubview(previewView)
         self.previewView.translatesAutoresizingMaskIntoConstraints = false

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -52,13 +52,11 @@ extension AuthViewController {
         self.stackView.translatesAutoresizingMaskIntoConstraints = false
         self.stackView.topAnchor.constraint(equalTo: self.scrollView.topAnchor).isActive = true
         self.stackView.bottomAnchor.constraint(equalTo: self.scrollView.bottomAnchor, constant: -20).isActive = true
-        self.stackView.leadingAnchor.constraint(equalTo: self.scrollView.leadingAnchor, constant: 20).isActive = true
-        self.stackView.trailingAnchor.constraint(equalTo: self.scrollView.trailingAnchor, constant: -20).isActive = true
+        self.stackView.leadingAnchor.constraint(equalTo: self.scrollView.leadingAnchor).isActive = true
+        self.stackView.trailingAnchor.constraint(equalTo: self.scrollView.trailingAnchor).isActive = true
         self.stackView.centerXAnchor.constraint(equalTo: self.scrollView.centerXAnchor).isActive = true
 
         self.stackView.addArrangedSubview(authMethodView)
-        self.authMethodView.translatesAutoresizingMaskIntoConstraints = false
-        self.authMethodView.heightAnchor.constraint(equalToConstant: 240).isActive = true
 
         self.stackView.addArrangedSubview(previewView)
         self.previewView.translatesAutoresizingMaskIntoConstraints = false
@@ -73,7 +71,7 @@ extension AuthViewController {
     private func configureNavigationBar() {
         self.navigationItem.largeTitleDisplayMode = .never
     }
-    
+
     private func configureDelegates() {
         self.imagePicker.delegate = self
         self.previewView.delegate = self

--- a/Routinus/Routinus/Presentation/Auth/AuthViewModel.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewModel.swift
@@ -10,6 +10,8 @@ import Foundation
 
 protocol AuthViewModelInput {
     func didTappedAuthButton()
+    func update(userAuthImageURL: String?)
+    func update(userAuthThumbnailImageURL: String?)
     func imageData(from directory: String,
                    filename: String,
                    completion: ((Data?) -> Void)?)
@@ -29,6 +31,9 @@ class AuthViewModel: AuthViewModelIO {
     var challengeFetchUsecase: ChallengeFetchableUsecase
     var imageFetchUsecase: ImageFetchableUsecase
     var imageSaveUsecase: ImageSavableUsecase
+    
+    private var userAuthImageURL: String
+    private var userAuthThumbnailImageURL: String
 
     init(challengeID: String,
          challengeFetchUsecase: ChallengeFetchableUsecase,
@@ -37,6 +42,8 @@ class AuthViewModel: AuthViewModelIO {
         self.challengeFetchUsecase = challengeFetchUsecase
         self.imageFetchUsecase = imageFetchUsecase
         self.imageSaveUsecase = imageSaveUsecase
+        self.userAuthImageURL = ""
+        self.userAuthThumbnailImageURL = ""
         self.fetchChallenge(challengeID: challengeID)
     }
 }
@@ -44,6 +51,14 @@ class AuthViewModel: AuthViewModelIO {
 extension AuthViewModel {
     func didTappedAuthButton() {
 
+    }
+    
+    func update(userAuthImageURL: String?) {
+        self.userAuthImageURL = userAuthImageURL ?? ""
+    }
+    
+    func update(userAuthThumbnailImageURL: String?) {
+        self.userAuthThumbnailImageURL = userAuthThumbnailImageURL ?? ""
     }
 
     func imageData(from directory: String,

--- a/Routinus/Routinus/Presentation/Auth/AuthViewModel.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewModel.swift
@@ -31,7 +31,8 @@ class AuthViewModel: AuthViewModelIO {
     var challengeFetchUsecase: ChallengeFetchableUsecase
     var imageFetchUsecase: ImageFetchableUsecase
     var imageSaveUsecase: ImageSavableUsecase
-    
+
+    private var challengeID: String
     private var userAuthImageURL: String
     private var userAuthThumbnailImageURL: String
 
@@ -39,6 +40,7 @@ class AuthViewModel: AuthViewModelIO {
          challengeFetchUsecase: ChallengeFetchableUsecase,
          imageFetchUsecase: ImageFetchableUsecase,
          imageSaveUsecase: ImageSavableUsecase) {
+        self.challengeID = challengeID
         self.challengeFetchUsecase = challengeFetchUsecase
         self.imageFetchUsecase = imageFetchUsecase
         self.imageSaveUsecase = imageSaveUsecase

--- a/Routinus/Routinus/Presentation/Auth/AuthViewModel.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewModel.swift
@@ -10,20 +10,33 @@ import Foundation
 
 protocol AuthViewModelInput {
     func didTappedAuthButton()
+    func imageData(from directory: String,
+                   filename: String,
+                   completion: ((Data?) -> Void)?)
+    func saveImage(to directory: String,
+                   filename: String,
+                   data: Data?) -> String?
 }
 
 protocol AuthViewModelOutput {
-    var challenge: PassthroughSubject<Challenge, Never> { get }
+    var challenge: CurrentValueSubject<Challenge?, Never> { get }
 }
 
 protocol AuthViewModelIO: AuthViewModelInput, AuthViewModelOutput { }
 
 class AuthViewModel: AuthViewModelIO {
-    var challenge = PassthroughSubject<Challenge, Never>()
+    var challenge = CurrentValueSubject<Challenge?, Never>(nil)
     var challengeFetchUsecase: ChallengeFetchableUsecase
+    var imageFetchUsecase: ImageFetchableUsecase
+    var imageSaveUsecase: ImageSavableUsecase
 
-    init(challengeID: String, challengeFetchUsecase: ChallengeFetchableUsecase) {
+    init(challengeID: String,
+         challengeFetchUsecase: ChallengeFetchableUsecase,
+         imageFetchUsecase: ImageFetchableUsecase,
+         imageSaveUsecase: ImageSavableUsecase) {
         self.challengeFetchUsecase = challengeFetchUsecase
+        self.imageFetchUsecase = imageFetchUsecase
+        self.imageSaveUsecase = imageSaveUsecase
         self.fetchChallenge(challengeID: challengeID)
     }
 }
@@ -32,13 +45,25 @@ extension AuthViewModel {
     func didTappedAuthButton() {
 
     }
+
+    func imageData(from directory: String,
+                   filename: String,
+                   completion: ((Data?) -> Void)? = nil) {
+        imageFetchUsecase.fetchImageData(from: directory, filename: filename) { data in
+            completion?(data)
+        }
+    }
+
+    func saveImage(to directory: String, filename: String, data: Data?) -> String? {
+        return imageSaveUsecase.saveImage(to: directory, filename: filename, data: data)
+    }
 }
 
 extension AuthViewModel {
     private func fetchChallenge(challengeID: String) {
         challengeFetchUsecase.fetchChallenge(challengeID: challengeID) { [weak self] challenge in
             guard let self = self else { return }
-            self.challenge.send(challenge)
+            self.challenge.value = challenge
         }
     }
 }

--- a/Routinus/Routinus/Presentation/Auth/Subviews/AuthButton.swift
+++ b/Routinus/Routinus/Presentation/Auth/Subviews/AuthButton.swift
@@ -31,6 +31,11 @@ final class AuthButton: UIButton {
     @objc func didTappedAuthButton() {
         delegate?.didTappedAuthButton()
     }
+    
+    func configureEnabled(isEnabled: Bool) {
+        self.isEnabled = isEnabled
+        self.alpha = isEnabled ? 1 : 0.5
+    }
 }
 
 protocol AuthButtonDelegate: AnyObject {

--- a/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
+++ b/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
@@ -10,6 +10,13 @@ import UIKit
 final class PreviewView: UIView {
     weak var delegate: PreviewViewDelegate?
 
+    private lazy var preview: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(named: "MainColor")
+
+        return view
+    }()
+
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
@@ -18,7 +25,7 @@ final class PreviewView: UIView {
         stackView.clipsToBounds = true
         return stackView
     }()
-    
+
     private lazy var authButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "camera.fill"), for: .normal)
@@ -80,8 +87,14 @@ extension PreviewView {
     }
 
     private func configureSubviews() {
-        self.backgroundColor = UIColor(named: "MainColor")
-        self.addSubview(stackView)
+        self.addSubview(preview)
+        self.preview.translatesAutoresizingMaskIntoConstraints = false
+        self.preview.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
+        self.preview.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
+        self.preview.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20).isActive = true
+        self.preview.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20).isActive = true
+        
+        preview.addSubview(stackView)
         self.stackView.translatesAutoresizingMaskIntoConstraints = false
         self.stackView.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
         self.stackView.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
@@ -94,7 +107,7 @@ extension PreviewView {
         self.previewLabel.widthAnchor.constraint(equalToConstant: 100).isActive = true
         [authButton, previewLabel].forEach { self.stackView.addArrangedSubview($0) }
 
-        self.addSubview(timeLabel)
+        preview.addSubview(timeLabel)
         self.timeLabel.translatesAutoresizingMaskIntoConstraints = false
         self.timeLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
         self.timeLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -10).isActive = true

--- a/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
+++ b/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
@@ -69,10 +69,6 @@ final class PreviewView: UIView {
         self.init(frame: CGRect.zero)
     }
 
-    @objc func didTappedAuthButton() {
-        self.delegate?.didTappedAuthButton()
-    }
-
     func setImage(_ image: UIImage) {
         let backgroundImage = UIImageView(frame: self.bounds)
         backgroundImage.image = image
@@ -84,6 +80,7 @@ final class PreviewView: UIView {
 extension PreviewView {
     private func configure() {
         configureSubviews()
+        configureGesture()
     }
 
     private func configureSubviews() {
@@ -93,7 +90,7 @@ extension PreviewView {
         self.preview.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
         self.preview.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20).isActive = true
         self.preview.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20).isActive = true
-        
+
         preview.addSubview(stackView)
         self.stackView.translatesAutoresizingMaskIntoConstraints = false
         self.stackView.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
@@ -112,8 +109,19 @@ extension PreviewView {
         self.timeLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
         self.timeLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -10).isActive = true
     }
+
+    private func configureGesture() {
+        let recognizer = UITapGestureRecognizer(target: self, action: #selector(didTappedPreview(_:)))
+        self.preview.isUserInteractionEnabled = true
+        self.preview.addGestureRecognizer(recognizer)
+    }
+
+    @objc private func didTappedPreview(_ sender: UITapGestureRecognizer) {
+        guard sender.state == .ended else { return }
+        delegate?.didTappedPreview()
+    }
 }
 
 protocol PreviewViewDelegate: AnyObject {
-    func didTappedAuthButton()
+    func didTappedPreview()
 }

--- a/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
+++ b/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
@@ -13,7 +13,6 @@ final class PreviewView: UIView {
     private lazy var preview: UIView = {
         let view = UIView()
         view.backgroundColor = UIColor(named: "MainColor")
-
         return view
     }()
 

--- a/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
+++ b/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
@@ -70,10 +70,10 @@ final class PreviewView: UIView {
     }
 
     func setImage(_ image: UIImage) {
-        let backgroundImage = UIImageView(frame: self.bounds)
+        let backgroundImage = UIImageView(frame: preview.bounds)
         backgroundImage.image = image
         backgroundImage.contentMode = .scaleToFill
-        self.insertSubview(backgroundImage, at: 0)
+        self.preview.addSubview(backgroundImage)
     }
 }
 

--- a/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
+++ b/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
@@ -11,6 +11,7 @@ final class PreviewView: UIView {
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
+        stackView.alignment = .center
         stackView.spacing = 10
         stackView.clipsToBounds = true
         return stackView
@@ -26,6 +27,7 @@ final class PreviewView: UIView {
     private lazy var previewLabel: UILabel = {
         let label = UILabel()
         label.text = "Preview"
+        label.textAlignment = .center
         label.font = UIFont.boldSystemFont(ofSize: 26)
         return label
     }()
@@ -67,6 +69,9 @@ extension PreviewView {
         self.previewImageView.translatesAutoresizingMaskIntoConstraints = false
         self.previewImageView.widthAnchor.constraint(equalToConstant: 60).isActive = true
         self.previewImageView.heightAnchor.constraint(equalToConstant: 60).isActive = true
+
+        self.previewLabel.translatesAutoresizingMaskIntoConstraints = false
+        self.previewLabel.widthAnchor.constraint(equalToConstant: 100).isActive = true
         [previewImageView, previewLabel].forEach { self.stackView.addArrangedSubview($0) }
 
         self.addSubview(timeLabel)

--- a/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
+++ b/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
@@ -110,12 +110,12 @@ extension PreviewView {
     }
 
     private func configureGesture() {
-        let recognizer = UITapGestureRecognizer(target: self, action: #selector(didTappedPreview(_:)))
+        let recognizer = UITapGestureRecognizer(target: self, action: #selector(didTappedPreviewView(_:)))
         self.previewView.isUserInteractionEnabled = true
         self.previewView.addGestureRecognizer(recognizer)
     }
 
-    @objc private func didTappedPreview(_ sender: UITapGestureRecognizer) {
+    @objc private func didTappedPreviewView(_ sender: UITapGestureRecognizer) {
         guard sender.state == .ended else { return }
         delegate?.didTappedPreviewView()
     }

--- a/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
+++ b/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
@@ -63,8 +63,14 @@ final class PreviewView: UIView {
     }
 
     @objc func didTappedAuthButton() {
-        print("touch")
         self.delegate?.didTappedAuthButton()
+    }
+
+    func setImage(_ image: UIImage) {
+        let backgroundImage = UIImageView(frame: self.bounds)
+        backgroundImage.image = image
+        backgroundImage.contentMode = .scaleToFill
+        self.insertSubview(backgroundImage, at: 0)
     }
 }
 

--- a/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
+++ b/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
@@ -36,7 +36,7 @@ final class PreviewView: UIView {
         button.imageEdgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
         button.layer.borderWidth = 1
         button.layer.cornerRadius = 15
-        button.addTarget(self, action: #selector(didTappedAuthButton), for: .touchUpInside)
+        button.isUserInteractionEnabled = false
         return button
     }()
 

--- a/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
+++ b/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
@@ -10,7 +10,7 @@ import UIKit
 final class PreviewView: UIView {
     weak var delegate: PreviewViewDelegate?
 
-    private lazy var preview: UIView = {
+    private lazy var previewView: UIView = {
         let view = UIView()
         view.backgroundColor = UIColor(named: "MainColor")
         return view
@@ -69,10 +69,10 @@ final class PreviewView: UIView {
     }
 
     func setImage(_ image: UIImage) {
-        let backgroundImage = UIImageView(frame: preview.bounds)
+        let backgroundImage = UIImageView(frame: previewView.bounds)
         backgroundImage.image = image
         backgroundImage.contentMode = .scaleToFill
-        self.preview.addSubview(backgroundImage)
+        self.previewView.addSubview(backgroundImage)
     }
 }
 
@@ -83,14 +83,14 @@ extension PreviewView {
     }
 
     private func configureSubviews() {
-        self.addSubview(preview)
-        self.preview.translatesAutoresizingMaskIntoConstraints = false
-        self.preview.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
-        self.preview.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
-        self.preview.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20).isActive = true
-        self.preview.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20).isActive = true
+        self.addSubview(previewView)
+        self.previewView.translatesAutoresizingMaskIntoConstraints = false
+        self.previewView.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
+        self.previewView.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
+        self.previewView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20).isActive = true
+        self.previewView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20).isActive = true
 
-        preview.addSubview(stackView)
+        previewView.addSubview(stackView)
         self.stackView.translatesAutoresizingMaskIntoConstraints = false
         self.stackView.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
         self.stackView.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
@@ -103,7 +103,7 @@ extension PreviewView {
         self.previewLabel.widthAnchor.constraint(equalToConstant: 100).isActive = true
         [authButton, previewLabel].forEach { self.stackView.addArrangedSubview($0) }
 
-        preview.addSubview(timeLabel)
+        previewView.addSubview(timeLabel)
         self.timeLabel.translatesAutoresizingMaskIntoConstraints = false
         self.timeLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
         self.timeLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -10).isActive = true
@@ -111,16 +111,16 @@ extension PreviewView {
 
     private func configureGesture() {
         let recognizer = UITapGestureRecognizer(target: self, action: #selector(didTappedPreview(_:)))
-        self.preview.isUserInteractionEnabled = true
-        self.preview.addGestureRecognizer(recognizer)
+        self.previewView.isUserInteractionEnabled = true
+        self.previewView.addGestureRecognizer(recognizer)
     }
 
     @objc private func didTappedPreview(_ sender: UITapGestureRecognizer) {
         guard sender.state == .ended else { return }
-        delegate?.didTappedPreview()
+        delegate?.didTappedPreviewView()
     }
 }
 
 protocol PreviewViewDelegate: AnyObject {
-    func didTappedPreview()
+    func didTappedPreviewView()
 }

--- a/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
+++ b/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
@@ -71,7 +71,8 @@ final class PreviewView: UIView {
     func setImage(_ image: UIImage) {
         let backgroundImage = UIImageView(frame: previewView.bounds)
         backgroundImage.image = image
-        backgroundImage.contentMode = .scaleToFill
+        backgroundImage.contentMode = .scaleAspectFill
+        backgroundImage.clipsToBounds = true
         self.previewView.addSubview(backgroundImage)
     }
 }

--- a/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
+++ b/Routinus/Routinus/Presentation/Auth/Subviews/PreviewView.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 final class PreviewView: UIView {
+    weak var delegate: PreviewViewDelegate?
+
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
@@ -16,12 +18,19 @@ final class PreviewView: UIView {
         stackView.clipsToBounds = true
         return stackView
     }()
-
-    private lazy var previewImageView: UIImageView = {
-        let imageView = UIImageView(image: UIImage(systemName: "camera.fill"))
-        imageView.tintColor = .black
-        imageView.contentMode = .scaleAspectFill
-        return imageView
+    
+    private lazy var authButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "camera.fill"), for: .normal)
+        button.tintColor = .black
+        button.imageView?.contentMode = .scaleAspectFit
+        button.contentVerticalAlignment = .fill
+        button.contentHorizontalAlignment = .fill
+        button.imageEdgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+        button.layer.borderWidth = 1
+        button.layer.cornerRadius = 15
+        button.addTarget(self, action: #selector(didTappedAuthButton), for: .touchUpInside)
+        return button
     }()
 
     private lazy var previewLabel: UILabel = {
@@ -52,6 +61,11 @@ final class PreviewView: UIView {
     convenience init() {
         self.init(frame: CGRect.zero)
     }
+
+    @objc func didTappedAuthButton() {
+        print("touch")
+        self.delegate?.didTappedAuthButton()
+    }
 }
 
 extension PreviewView {
@@ -66,17 +80,21 @@ extension PreviewView {
         self.stackView.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
         self.stackView.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
 
-        self.previewImageView.translatesAutoresizingMaskIntoConstraints = false
-        self.previewImageView.widthAnchor.constraint(equalToConstant: 60).isActive = true
-        self.previewImageView.heightAnchor.constraint(equalToConstant: 60).isActive = true
+        self.authButton.translatesAutoresizingMaskIntoConstraints = false
+        self.authButton.widthAnchor.constraint(equalToConstant: 80).isActive = true
+        self.authButton.heightAnchor.constraint(equalToConstant: 80).isActive = true
 
         self.previewLabel.translatesAutoresizingMaskIntoConstraints = false
         self.previewLabel.widthAnchor.constraint(equalToConstant: 100).isActive = true
-        [previewImageView, previewLabel].forEach { self.stackView.addArrangedSubview($0) }
+        [authButton, previewLabel].forEach { self.stackView.addArrangedSubview($0) }
 
         self.addSubview(timeLabel)
         self.timeLabel.translatesAutoresizingMaskIntoConstraints = false
         self.timeLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
         self.timeLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -10).isActive = true
     }
+}
+
+protocol PreviewViewDelegate: AnyObject {
+    func didTappedAuthButton()
 }

--- a/Routinus/Routinus/Presentation/Common/Subviews/AuthMethodView.swift
+++ b/Routinus/Routinus/Presentation/Common/Subviews/AuthMethodView.swift
@@ -50,6 +50,15 @@ final class AuthMethodView: UIView {
     convenience init() {
         self.init(frame: CGRect.zero)
     }
+
+    func configureMethodLabel(introduction: String) {
+        self.methodLabel.text = introduction
+    }
+
+    func configureMethodImage(data: Data?) {
+        guard let data = data else { return }
+        self.methodImageView.image = UIImage(data: data)
+    }
 }
 
 extension AuthMethodView {

--- a/Routinus/Routinus/Presentation/Create/Subviews/CreateWeekView.swift
+++ b/Routinus/Routinus/Presentation/Create/Subviews/CreateWeekView.swift
@@ -143,6 +143,6 @@ extension CreateWeekView {
     }
 
     func updateEndDate(date: Date) {
-        endDateLabel.text = date.toExtendedString()
+        endDateLabel.text = date.toDateWithWeekdayString()
     }
 }

--- a/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
@@ -168,7 +168,7 @@ extension HomeViewModel {
 
     private func generateDay(offsetBy dayOffset: Int, for baseDate: Date, isWithinDisplayedMonth: Bool) -> Day {
         let date = calendar.date(byAdding: .day, value: dayOffset, to: baseDate) ?? baseDate
-        let achievement = achievements.filter { "\($0.yearMonth)\($0.day)" == date.toString() }
+        let achievement = achievements.filter { "\($0.yearMonth)\($0.day)" == date.toDateString() }
         return Day(
             date: date,
             number: "\(date.day)",

--- a/Routinus/Routinus/Presentation/Home/Subviews/CalendarHeader.swift
+++ b/Routinus/Routinus/Presentation/Home/Subviews/CalendarHeader.swift
@@ -73,7 +73,7 @@ final class CalendarHeader: UIView {
     var baseDate = Date() {
         didSet {
             monthLabel.text = dateFormatter.string(from: baseDate)
-            todayButton.isHidden = baseDate.toString() == Date().toString()
+            todayButton.isHidden = baseDate.toDateString() == Date().toDateString()
         }
     }
 

--- a/Routinus/RoutinusDatabase/DTO/ChallengeAuthDTO.swift
+++ b/Routinus/RoutinusDatabase/DTO/ChallengeAuthDTO.swift
@@ -1,0 +1,60 @@
+//
+//  ChallengeAuthDTO.swift
+//  RoutinusDatabase
+//
+//  Created by 박상우 on 2021/11/17.
+//
+
+import Foundation
+
+public struct ChallengeAuthDTO {
+    public let document: ChallengeAuthFields?
+
+    init() {
+        self.document = nil
+    }
+    
+    public init(challengeID: String,
+                userID: String,
+                date: String,
+                time: String) {
+        let field = ChallengeAuthField(challengeID: ChallengeAuthField.ChallengeID(stringValue: challengeID),
+                                       userID: ChallengeAuthField.UserID(stringValue: userID),
+                                       date: ChallengeAuthField.Date(stringValue: date),
+                                       time: ChallengeAuthField.Time(stringValue: time))
+        self.document = ChallengeAuthFields(fields: field)
+    }
+}
+
+public struct ChallengeAuthFields: Codable {
+    public let fields: ChallengeAuthField
+}
+
+public struct ChallengeAuthField: Codable {
+    public struct ChallengeID: Codable {
+        public let stringValue: String
+    }
+
+    public struct UserID: Codable {
+        public let stringValue: String
+    }
+
+    public struct Date: Codable {
+        public let stringValue: String
+    }
+
+    public struct Time: Codable {
+        public let stringValue: String
+    }
+
+    public let challengeID: ChallengeID
+    public let userID: UserID
+    public let date: Date
+    public let time: Time
+
+    public enum CodingKeys: String, CodingKey {
+        case date, time
+        case challengeID = "challenge_id"
+        case userID = "user_id"
+    }
+}

--- a/Routinus/RoutinusDatabase/RoutinusQuery.swift
+++ b/Routinus/RoutinusDatabase/RoutinusQuery.swift
@@ -53,6 +53,19 @@ internal enum RoutinusQuery {
         }
         """.data(using: .utf8)
     }
+    
+    internal static func insertChallengeAuthQuery(document: ChallengeAuthField) -> Data? {
+        return """
+        {
+            "fields": {
+                "challenge_id": { "stringValue": "\(document.challengeID.stringValue)" },
+                "user_id": { "stringValue": "\(document.userID.stringValue)" },
+                "date": { "stringValue": "\(document.date.stringValue)" },
+                "time": { "stringValue": "\(document.time.stringValue)" }
+            }
+        }
+        """.data(using: .utf8)
+    }
 
     internal static func userQuery(of id: String) -> Data? {
         return """


### PR DESCRIPTION
## 관련 issue

Closes #153
Closes #155
Closes #159
Closes #163
Closes #165 
Closes #166
Closes #169
Closes #171 
Closes #173 

## 작업 내용

view
- [x] 인증방법 이미지 및 인증방법 설명 표시
- [x] Preview 전체 클릭 시 ImagePicker호출 
- [x] 인증하기 버튼 인증여부에 따른 비활성화
- [x] 인증하기 버튼 누르면 이전 화면으로 돌아가기 

data
- [x] challengeAuth Entity 추가
- [x] challengeAuthDTO 추가
- [x] ChallengeAuthCreateUsecase, ChallengeAuthRepository 추가
- [x] RoutinusDatabase, Query challenge_auth 생성 로직 추가 
- [x] 인증하기 버튼 누를시 challenge_auth 컬렉션 데이터 추가

## 기타 사항

- challenge_auth 컬렉션만 데이터 추가부분이 되어있고 achievement, challenge_participant, user 부분 업데이트는
아직 반영이 안되어 있습니다.
추후에 나머지 컬렉션도 업데이트 한 후 홈화면에서 변경부분 확인하면 될 것 같습니다!

