### PR TITLE
[챌린지 추가화면] iOS 14 이상이면 UImenu, 이하는 actionSheet로 동작

### DIFF
--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -179,6 +179,11 @@ extension CreateViewController: CreateSubviewDelegate {
     func didChange(authExampleImageURL: String) {
         viewModel?.update(authExampleImageURL: authExampleImageURL)
     }
+
+    func didTappedCategoryButton() {
+        let alert = categoryView.categoryAction
+        present(alert, animated: true, completion: nil)
+    }
 }
 
 extension CreateViewController: UITextFieldDelegate, UITextViewDelegate {
@@ -217,7 +222,9 @@ extension CreateViewController: UITextFieldDelegate, UITextViewDelegate {
         }
     }
 
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+    func textField(_ textField: UITextField,
+                   shouldChangeCharactersIn range: NSRange,
+                   replacementString string: String) -> Bool {
         guard let viewModel = viewModel, let currentText = textField.text else { return true }
         switch textField.tag {
         case InputTag.title.rawValue:
@@ -229,7 +236,9 @@ extension CreateViewController: UITextFieldDelegate, UITextViewDelegate {
         }
     }
 
-    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+    func textView(_ textView: UITextView,
+                  shouldChangeTextIn range: NSRange,
+                  replacementText text: String) -> Bool {
         guard let viewModel = viewModel, let currentText = textView.text else { return true }
         switch textView.tag {
         case InputTag.introduction.rawValue:

--- a/Routinus/Routinus/Presentation/Create/Delegates/CreateSubviewDelegate.swift
+++ b/Routinus/Routinus/Presentation/Create/Delegates/CreateSubviewDelegate.swift
@@ -11,4 +11,5 @@ protocol CreateSubviewDelegate: AnyObject {
     func didChange(category: Challenge.Category)
     func didChange(imageURL: String)
     func didChange(authExampleImageURL: String)
+    func didTappedCategoryButton()
 }

--- a/Routinus/Routinus/Presentation/Create/Subviews/CreateCategoryView.swift
+++ b/Routinus/Routinus/Presentation/Create/Subviews/CreateCategoryView.swift
@@ -106,6 +106,18 @@ extension CreateCategoryView {
             }
             alert.addAction(action)
         }
+
+        let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+        alert.addAction(cancel)
+
+        let height = NSLayoutConstraint(item: alert.view,
+                                        attribute: NSLayoutConstraint.Attribute.height,
+                                        relatedBy: NSLayoutConstraint.Relation.equal,
+                                        toItem: nil,
+                                        attribute: NSLayoutConstraint.Attribute.notAnAttribute,
+                                        multiplier: 1,
+                                        constant: UIScreen.main.bounds.height * 0.6)
+        alert.view.addConstraint(height)
         return alert
     }
 }

--- a/Routinus/Routinus/Presentation/Create/Subviews/CreateCategoryView.swift
+++ b/Routinus/Routinus/Presentation/Create/Subviews/CreateCategoryView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class CreateCategoryView: UIView {
     weak var delegate: CreateSubviewDelegate?
-    
+
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.text = "어떤 주제와 관련이 있나요?"
@@ -52,7 +52,9 @@ extension CreateCategoryView {
 
         var actions = [UIAction]()
         for category in Challenge.Category.allCases {
-            let image = UIImage(systemName: category.symbol) == nil ? UIImage(named: category.symbol) : UIImage(systemName: category.symbol)
+            let image = UIImage(systemName: category.symbol) == nil
+                        ? UIImage(named: category.symbol)
+                        : UIImage(systemName: category.symbol)
             let action = UIAction(title: category.title, image: image) { [weak self] _ in
                 guard let self = self else { return }
                 self.delegate?.didChange(category: category)
@@ -60,12 +62,17 @@ extension CreateCategoryView {
             }
             actions.append(action)
         }
-        button.menu = UIMenu(title: "",
-                             image: nil,
-                             identifier: nil,
-                             options: .displayInline,
-                             children: actions)
-        button.showsMenuAsPrimaryAction = true
+
+        if #available(iOS 14.0, *) {
+            button.menu = UIMenu(title: "",
+                                 image: nil,
+                                 identifier: nil,
+                                 options: .displayInline,
+                                 children: actions)
+            button.showsMenuAsPrimaryAction = true
+        } else {
+            button.addTarget(self, action: #selector(didTappedCategoryButton), for: .touchUpInside)
+        }
     }
 
     private func configureLayouts() {
@@ -79,5 +86,26 @@ extension CreateCategoryView {
                       width: 100, height: 40)
 
         anchor(bottom: button.bottomAnchor)
+    }
+
+    @objc func didTappedCategoryButton(_ sender: UIButton) {
+        delegate?.didTappedCategoryButton()
+    }
+
+    var categoryAction: UIAlertController {
+        let alert = UIAlertController(title: "카테고리",
+                                      message: nil,
+                                      preferredStyle: .actionSheet)
+
+        for category in Challenge.Category.allCases {
+            let action = UIAlertAction(title: category.title,
+                                       style: .default) { [weak self] _ in
+                guard let self = self else { return }
+                    self.delegate?.didChange(category: category)
+                    self.button.configuration?.title = category.title
+            }
+            alert.addAction(action)
+        }
+        return alert
     }
 }


### PR DESCRIPTION
## 관련 issue

close #221 

## 작업 내용
- 14 이상
  - ![Simulator Screen Shot - iPhone 12 - 2021-11-18 at 14 01 27](https://user-images.githubusercontent.com/37893327/142356721-4745c8c6-0022-41cd-93da-64eb72ea2780.png)

- 13 이하
  - ![Simulator Screen Shot - iPhone 12 - 2021-11-18 at 14 00 45](https://user-images.githubusercontent.com/37893327/142356734-55763165-21ec-426a-ac17-76b00045cbde.png)

- [x] iOS 14 이상이면 UIMenu, 이하는 actionSheet로 동작하도록 수정


## 기타 사항
- 취소하기 버튼도 넣을까요?

- 우리도 13으로 배포..!!