### PR TITLE
[챌린지 상세 화면] 인증 fetch 로직 & 인증하기 화면 연결  

### DIFF
--- a/Routinus/Routinus.xcodeproj/project.pbxproj
+++ b/Routinus/Routinus.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		1497CF442738FFA600296F9E /* RoutinusRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1497CF432738FFA600296F9E /* RoutinusRepository.swift */; };
 		1497CF4C2739078700296F9E /* UserNameFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1497CF4B2739078700296F9E /* UserNameFactory.swift */; };
 		1497CF572739215C00296F9E /* UserCreateUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1497CF562739215C00296F9E /* UserCreateUsecase.swift */; };
+		14AFD0FA2746211F00011CC1 /* ChallengeAuthFetchUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AFD0F92746211F00011CC1 /* ChallengeAuthFetchUsecase.swift */; };
 		14B1810E27454DBF0061F2AE /* ParticipationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B1810D27454DBF0061F2AE /* ParticipationRepository.swift */; };
 		14B181122745511A0061F2AE /* Participation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B181112745511A0061F2AE /* Participation.swift */; };
 		14B18116274555CE0061F2AE /* ParticipationFetchUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B18115274555CE0061F2AE /* ParticipationFetchUsecase.swift */; };
@@ -186,6 +187,7 @@
 		1497CF432738FFA600296F9E /* RoutinusRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutinusRepository.swift; sourceTree = "<group>"; };
 		1497CF4B2739078700296F9E /* UserNameFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNameFactory.swift; sourceTree = "<group>"; };
 		1497CF562739215C00296F9E /* UserCreateUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCreateUsecase.swift; sourceTree = "<group>"; };
+		14AFD0F92746211F00011CC1 /* ChallengeAuthFetchUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeAuthFetchUsecase.swift; sourceTree = "<group>"; };
 		14B1810D27454DBF0061F2AE /* ParticipationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipationRepository.swift; sourceTree = "<group>"; };
 		14B181112745511A0061F2AE /* Participation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Participation.swift; sourceTree = "<group>"; };
 		14B18115274555CE0061F2AE /* ParticipationFetchUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipationFetchUsecase.swift; sourceTree = "<group>"; };
@@ -605,6 +607,7 @@
 				E901EFD52744BDBD00B14847 /* ImageFetchUsecase.swift */,
 				E901EFE32744D41600B14847 /* ImageSaveUsecase.swift */,
 				E901EFE927453F2000B14847 /* ChallengeAuthCreateUsecase.swift */,
+				14AFD0F92746211F00011CC1 /* ChallengeAuthFetchUsecase.swift */,
 				14B18115274555CE0061F2AE /* ParticipationFetchUsecase.swift */,
 				14B18117274561E20061F2AE /* ParticipationCreateUsecase.swift */,
 			);
@@ -1111,6 +1114,7 @@
 				E93704492743B2F800D82B1D /* AuthViewModel.swift in Sources */,
 				E9797CA22730FFAD00A14A0F /* TabBarCoordinator.swift in Sources */,
 				E9493DC8273A70280095CF6D /* SearchPopularKeywordCell.swift in Sources */,
+				14AFD0FA2746211F00011CC1 /* ChallengeAuthFetchUsecase.swift in Sources */,
 				441CEE17273A33CD006C261F /* CreateIntroductionView.swift in Sources */,
 				E99474502736D54C0054A631 /* DetailCoordinator.swift in Sources */,
 				145F5324273FAF95000700A5 /* ChallengeUpdateUsecase.swift in Sources */,

--- a/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
@@ -40,10 +40,21 @@ final class DetailCoordinator: RoutinusCoordinator {
         self.navigationController.pushViewController(detailViewController, animated: true)
 
         detailViewModel.editBarButtonTap
-            .sink { [weak self] challengeID  in
+            .sink { [weak self] challengeID in
                 guard let self = self else { return }
                 let createCoordinator = CreateCoordinator(navigationController: self.navigationController, challengeID: challengeID)
                 createCoordinator.start()
+                self.childCoordinator.append(createCoordinator)
+            }
+            .store(in: &cancellables)
+
+        detailViewModel.authButtonTap
+            .sink { [ weak self ] challengeID in
+                guard let self = self else { return }
+                let authCoordinator = AuthCoordinator(navigationController: self.navigationController,
+                                                      challengeID: challengeID)
+                authCoordinator.start()
+                self.childCoordinator.append(authCoordinator)
             }
             .store(in: &cancellables)
     }

--- a/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
@@ -37,6 +37,7 @@ final class DetailCoordinator: RoutinusCoordinator {
                                               userFetchUsecase: userFetchUsecase,
                                               challengeAuthFetchUsecase: challengeAuthFetchUsecase)
         let detailViewController = DetailViewController(with: detailViewModel)
+        detailViewController.hidesBottomBarWhenPushed = true
         self.navigationController.pushViewController(detailViewController, animated: true)
 
         detailViewModel.editBarButtonTap

--- a/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
@@ -28,12 +28,14 @@ final class DetailCoordinator: RoutinusCoordinator {
         let participationFetchUsecase = ParticipationFetchUsecase(repository: repository)
         let participationCreateUsecase = ParticipationCreateUsecase(repository: repository)
         let userFetchUsecase = UserFetchUsecase(repository: repository)
+        let challengeAuthFetchUsecase = ChallengeAuthFetchUsecase(repository: repository)
         let detailViewModel = DetailViewModel(challengeID: challengeID,
                                               challengeFetchUsecase: challengeFetchUsecase,
                                               imageFetchUsecase: imageFetchUsecase,
                                               participationFetchUsecase: participationFetchUsecase,
                                               participationCreateUsecase: participationCreateUsecase,
-                                              userFetchUsecase: userFetchUsecase)
+                                              userFetchUsecase: userFetchUsecase,
+                                              challengeAuthFetchUsecase: challengeAuthFetchUsecase)
         let detailViewController = DetailViewController(with: detailViewModel)
         self.navigationController.pushViewController(detailViewController, animated: true)
 

--- a/Routinus/Routinus/Application/Coordinator/SearchCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/SearchCoordinator.swift
@@ -36,6 +36,7 @@ final class SearchCoordinator: RoutinusCoordinator {
                     navigationController: self.navigationController, challengeID: challengeID
                 )
                 detailCoordinator.start()
+                self.childCoordinator.append(detailCoordinator)
             }
             .store(in: &cancellables)
     }

--- a/Routinus/Routinus/Data/ChallengeAuthRepository.swift
+++ b/Routinus/Routinus/Data/ChallengeAuthRepository.swift
@@ -14,6 +14,10 @@ protocol ChallengeAuthRepository {
     func save(challengeAuth: ChallengeAuth,
               userAuthImageURL: String,
               userAuthThumbnailImageURL: String)
+    func fetchChallengeAuth(todayDate: String,
+                            userID: String,
+                            challengeID: String,
+                            completion: @escaping (ChallengeAuth?) -> Void)
 }
 
 extension RoutinusRepository: ChallengeAuthRepository {
@@ -34,4 +38,21 @@ extension RoutinusRepository: ChallengeAuthRepository {
             RoutinusImageManager.removeTempCachedImages()
         }
     }
+
+    func fetchChallengeAuth(todayDate: String,
+                            userID: String,
+                            challengeID: String,
+                            completion: @escaping (ChallengeAuth?) -> Void) {
+        RoutinusDatabase.challengeAuth(todayDate: todayDate,
+                                       userID: userID,
+                                       challengeID: challengeID) { dto in
+            guard let dto = dto,
+                  dto.document != nil else {
+                completion(nil)
+                return
+            }
+            completion(ChallengeAuth(challengeAuthDTO: dto))
+        }
+    }
+
 }

--- a/Routinus/Routinus/Domain/Usecase/ChallengeAuthCreateUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/ChallengeAuthCreateUsecase.swift
@@ -34,6 +34,4 @@ struct ChallengeAuthCreateUsecase: ChallengeAuthCreatableUsecase {
                         userAuthImageURL: userAuthImageURL,
                         userAuthThumbnailImageURL: userAuthThumbnailImageURL)
     }
-    
-    
 }

--- a/Routinus/Routinus/Domain/Usecase/ChallengeAuthFetchUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/ChallengeAuthFetchUsecase.swift
@@ -1,0 +1,30 @@
+//
+//  ChallengeAuthFetchUsecase.swift
+//  Routinus
+//
+//  Created by 백지현 on 2021/11/18.
+//
+
+import Foundation
+
+protocol ChallengeAuthFetchableUsecase {
+    func fetchChallengeAuth(challengeID: String,
+                            completion: @escaping (ChallengeAuth?) -> Void)
+}
+
+struct ChallengeAuthFetchUsecase: ChallengeAuthFetchableUsecase {
+    var repository: ChallengeAuthRepository
+
+    init(repository: ChallengeAuthRepository) {
+        self.repository = repository
+    }
+
+    func fetchChallengeAuth(challengeID: String, completion: @escaping (ChallengeAuth?) -> Void) {
+        guard let userID = RoutinusRepository.userID() else { return }
+        repository.fetchChallengeAuth(todayDate: Date().toDateString(),
+                                      userID: userID,
+                                      challengeID: challengeID) { challengeAuth in
+            completion(challengeAuth)
+        }
+    }
+}

--- a/Routinus/Routinus/Domain/Usecase/ParticipationFetchUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/ParticipationFetchUsecase.swift
@@ -18,7 +18,6 @@ struct ParticipationFetchUsecase: ParticipationFetchableUsecase {
         self.repository = repository
     }
 
-    // TODO: auth 인증 fetch + escaping: (Participation?, Auth?) -> Void 로 전달
     func fetchParticipation(challengeID: String, completion: @escaping (Participation?) -> Void) {
         guard let userID = RoutinusRepository.userID() else {
             completion(nil)

--- a/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
+++ b/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
@@ -185,7 +185,6 @@ final class DetailViewController: UIViewController {
 
 extension DetailViewController: ParticipantButtonDelegate {
     func didTappedParticipantButton() {
-        viewModel?.didTappedParticipationButton()
+        viewModel?.didTappedParticipationAuthButton()
     }
 }
-

--- a/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
+++ b/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
@@ -159,7 +159,7 @@ final class DetailViewController: UIViewController {
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] _ in
                 guard let self = self else { return }
-                self.showAlert()
+                self.presentAlert()
             })
             .store(in: &cancellables)
     }
@@ -168,7 +168,7 @@ final class DetailViewController: UIViewController {
         participantButton.delegate = self
     }
 
-    private func showAlert() {
+    private func presentAlert() {
         let alert = UIAlertController(title: "알림", message: "챌린지에 참여되었습니다.", preferredStyle: .alert)
         let confirm = UIAlertAction(title: "확인", style: .default, handler: nil)
         let close = UIAlertAction(title: "닫기", style: .destructive, handler: nil)

--- a/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
+++ b/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
@@ -154,10 +154,28 @@ final class DetailViewController: UIViewController {
                 self.participantButton.update(to: participationState)
             })
             .store(in: &cancellables)
+
+        self.viewModel?.participationButtonTap
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] _ in
+                guard let self = self else { return }
+                self.showAlert()
+            })
+            .store(in: &cancellables)
     }
 
     private func configureDelegate() {
         participantButton.delegate = self
+    }
+
+    private func showAlert() {
+        let alert = UIAlertController(title: "알림", message: "챌린지에 참여되었습니다.", preferredStyle: .alert)
+        let confirm = UIAlertAction(title: "확인", style: .default, handler: nil)
+        let close = UIAlertAction(title: "닫기", style: .destructive, handler: nil)
+
+        alert.addAction(confirm)
+        alert.addAction(close)
+        present(alert, animated: true, completion: nil)
     }
 
     @objc private func didTappedEditBarButton(_ sender: UIBarButtonItem) {

--- a/Routinus/Routinus/Presentation/Detail/DetailViewModel.swift
+++ b/Routinus/Routinus/Presentation/Detail/DetailViewModel.swift
@@ -19,7 +19,7 @@ protocol DetailViewModelInput {
                    filename: String,
                    completion: ((Data?) -> Void)?)
     func didTappedEditBarButton()
-    func didTappedParticipationButton()
+    func didTappedParticipationAuthButton()
 }
 
 protocol DetailViewModelOutput {
@@ -77,7 +77,7 @@ extension DetailViewModel {
         self.editBarButtonTap.send(challengeID)
     }
 
-    func didTappedParticipationButton() {
+    func didTappedParticipationAuthButton() {
         guard let challengeID = challengeID else { return }
         if participationAuthState.value == .notParticipating {
             participationCreateUsecase.createParticipation(challengeID: challengeID)

--- a/Routinus/Routinus/Presentation/Detail/DetailViewModel.swift
+++ b/Routinus/Routinus/Presentation/Detail/DetailViewModel.swift
@@ -82,7 +82,7 @@ extension DetailViewModel {
         if participationAuthState.value == .notParticipating {
             participationCreateUsecase.createParticipation(challengeID: challengeID)
             self.participationAuthState.value = .notAuthenticating
-            // TODO: 참여하기 버튼 클릭 시 alert 띄우기
+            participationButtonTap.send()
         } else if participationAuthState.value == .notAuthenticating {
             authButtonTap.send(challengeID)
         }

--- a/Routinus/Routinus/Presentation/Detail/DetailViewModel.swift
+++ b/Routinus/Routinus/Presentation/Detail/DetailViewModel.swift
@@ -29,6 +29,7 @@ protocol DetailViewModelOutput {
     var challenge: PassthroughSubject<Challenge, Never> { get }
     var editBarButtonTap: PassthroughSubject<String, Never> { get }
     var participationButtonTap: PassthroughSubject<Void, Never> { get }
+    var authButtonTap: PassthroughSubject<String, Never> { get }
 }
 
 protocol DetailViewModelIO: DetailViewModelInput, DetailViewModelOutput { }
@@ -40,6 +41,7 @@ class DetailViewModel: DetailViewModelIO {
     var challenge = PassthroughSubject<Challenge, Never>()
     var editBarButtonTap = PassthroughSubject<String, Never>()
     var participationButtonTap = PassthroughSubject<Void, Never>()
+    var authButtonTap = PassthroughSubject<String, Never>()
 
     let challengeFetchUsecase: ChallengeFetchableUsecase
     let imageFetchUsecase: ImageFetchableUsecase
@@ -76,10 +78,13 @@ extension DetailViewModel {
     }
 
     func didTappedParticipationButton() {
+        guard let challengeID = challengeID else { return }
         if participationAuthState.value == .notParticipating {
-            guard let challengeID = challengeID else { return }
             participationCreateUsecase.createParticipation(challengeID: challengeID)
             self.participationAuthState.value = .notAuthenticating
+            // TODO: 참여하기 버튼 클릭 시 alert 띄우기
+        } else if participationAuthState.value == .notAuthenticating {
+            authButtonTap.send(challengeID)
         }
     }
 }

--- a/Routinus/Routinus/Presentation/Detail/DetailViewModel.swift
+++ b/Routinus/Routinus/Presentation/Detail/DetailViewModel.swift
@@ -97,7 +97,6 @@ extension DetailViewModel {
     private func fetchParticipation(completion: @escaping (Participation?) -> Void) {
         guard let challengeID = challengeID else { return }
         participationFetchUsecase.fetchParticipation(challengeID: challengeID) { [weak self] participation in
-            guard let self = self else { return }
             completion(participation)
         }
     }
@@ -105,7 +104,6 @@ extension DetailViewModel {
     private func fetchAuth(completion: @escaping (ChallengeAuth?) -> Void) {
         guard let challengeID = challengeID else { return }
         challengeAuthFetchUsecase.fetchChallengeAuth(challengeID: challengeID) { [weak self] challengeAuth in
-            guard let self = self else { return }
             completion(challengeAuth)
         }
     }

--- a/Routinus/Routinus/Presentation/Detail/DetailViewModel.swift
+++ b/Routinus/Routinus/Presentation/Detail/DetailViewModel.swift
@@ -99,7 +99,6 @@ extension DetailViewModel {
         participationFetchUsecase.fetchParticipation(challengeID: challengeID) { [weak self] participation in
             guard let self = self else { return }
             completion(participation)
-            // TODO: Participation 있는 경우에는 인증하기 or 인증완료 구분하기 TODO
         }
     }
 

--- a/Routinus/Routinus/Presentation/Detail/Subviews/ParticipantButton.swift
+++ b/Routinus/Routinus/Presentation/Detail/Subviews/ParticipantButton.swift
@@ -33,6 +33,8 @@ final class ParticipantButton: UIButton {
     }
 
     func update(to state: ParticipationAuthState) {
+        self.isEnabled = state == .authenticated ? false : true
+        self.alpha = state == .authenticated ? 0.5 : 1
         self.setTitle(state.rawValue, for: .normal)
     }
 }

--- a/Routinus/RoutinusDatabase/DTO/ChallengeAuthDTO.swift
+++ b/Routinus/RoutinusDatabase/DTO/ChallengeAuthDTO.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ChallengeAuthDTO {
+public struct ChallengeAuthDTO: Codable {
     public let document: ChallengeAuthFields?
 
     init() {

--- a/Routinus/RoutinusDatabase/RoutinusDatabase.swift
+++ b/Routinus/RoutinusDatabase/RoutinusDatabase.swift
@@ -472,7 +472,7 @@ public enum RoutinusDatabase {
         URLSession.shared.dataTask(with: request) { data, _, _ in
             guard let data = data else { return }
             let dto = try? JSONDecoder().decode([ChallengeAuthDTO].self, from: data).first 
-            completion(dto ?? nil)
+            completion(dto)
         }.resume()
     }
 }

--- a/Routinus/RoutinusDatabase/RoutinusDatabase.swift
+++ b/Routinus/RoutinusDatabase/RoutinusDatabase.swift
@@ -460,4 +460,19 @@ public enum RoutinusDatabase {
             completion(dto ?? nil)
         }.resume()
     }
+
+    public static func challengeAuth(todayDate: String, userID: String, challengeID: String, completion: @escaping (ChallengeAuthDTO?) -> Void) {
+        guard let url = URL(string: "\(firestoreURL):runQuery") else { return }
+        var request = URLRequest(url: url)
+
+        request.addValue("text/plain", forHTTPHeaderField: "Content-Type")
+        request.httpMethod = HTTPMethod.post.rawValue
+        request.httpBody = RoutinusQuery.challengeAuth(todayDate: todayDate, userID: userID, challengeID: challengeID)
+
+        URLSession.shared.dataTask(with: request) { data, _, _ in
+            guard let data = data else { return }
+            let dto = try? JSONDecoder().decode([ChallengeAuthDTO].self, from: data).first 
+            completion(dto ?? nil)
+        }.resume()
+    }
 }

--- a/Routinus/RoutinusDatabase/RoutinusQuery.swift
+++ b/Routinus/RoutinusDatabase/RoutinusQuery.swift
@@ -346,4 +346,42 @@ internal enum RoutinusQuery {
         """.data(using: .utf8)
     }
 
+    internal static func challengeAuth(todayDate: String, userID: String, challengeID: String) -> Data? {
+        return """
+        {
+            "structuredQuery": {
+                "from": { "collectionId": "challenge_auth" },
+                "where": {
+                    "compositeFilter": {
+                        "filters": [
+                            {
+                                "fieldFilter": {
+                                    "field": { "fieldPath": "user_id" },
+                                    "op": "EQUAL",
+                                    "value": { "stringValue": "\(userID)" }
+                                }
+                            },
+                            {
+                                "fieldFilter": {
+                                    "field": { "fieldPath": "challenge_id" },
+                                    "op": "EQUAL",
+                                    "value": { "stringValue": "\(challengeID)" }
+                                },
+                            },
+                            {
+                                "fieldFilter": {
+                                    "field": { "fieldPath": "date" },
+                                    "op": "EQUAL",
+                                    "value": { "stringValue": "\(todayDate)" }
+                                },
+                            }
+                        ],
+                        "op": "AND"
+                    }
+                }
+            }
+        }
+        """.data(using: .utf8)
+    }
+
 }


### PR DESCRIPTION
## 관련 issue
#150 
#151
#152
#154 
#158 
#160 
#162 
#164 
#168 
#170 
#172 
#176

## 작업 내용
- [x] AuthDTO 활용하여 AuthFetchUsecase, Database 기능 추가
- [x] 인증이 완료된 경우 인증 완료 버튼을 표시
- [x] 인증하기 버튼 클릭시 인증화면으로 연결
- [x]  상세화면 이동 시 탭 바 보이지 않도록 변경 

## 기타 사항
- 점심시간에 보낸 PR에 이슈 추가를 못해서 이곳에 이슈를 추가했습니다! 