### PR TITLE
[공통] 파일 이름 일관성있게 수정

### DIFF
--- a/Routinus/Routinus.xcodeproj/project.pbxproj
+++ b/Routinus/Routinus.xcodeproj/project.pbxproj
@@ -630,6 +630,7 @@
 			isa = PBXGroup;
 			children = (
 				44AAA2BF272FDF8F002E16C4 /* LaunchScreen.storyboard */,
+				E93704472743A95100D82B1D /* Common */,
 				E9797C9D2730F89400A14A0F /* Home */,
 				E9797CA52731066100A14A0F /* Challenge */,
 				E9797CB4273107E100A14A0F /* Search */,
@@ -638,7 +639,6 @@
 				E9797CB7273108EA00A14A0F /* Auth */,
 				E9797CA92731072700A14A0F /* Manage */,
 				E9797CA8273106E300A14A0F /* MyPage */,
-				E93704472743A95100D82B1D /* Common */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";

--- a/Routinus/Routinus.xcodeproj/project.pbxproj
+++ b/Routinus/Routinus.xcodeproj/project.pbxproj
@@ -9,10 +9,10 @@
 /* Begin PBXBuildFile section */
 		0D053E4E2746490A0042DAF2 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0D053E502746490A0042DAF2 /* Localizable.strings */; };
 		0D053E59274654390042DAF2 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D053E58274654390042DAF2 /* String+Extensions.swift */; };
-		0DBBAA3727341C1600B32EB5 /* CollectionViewLayouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBBAA3627341C1600B32EB5 /* CollectionViewLayouts.swift */; };
-		0DBBAA3C27341C3600B32EB5 /* ChallengeRecommendCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBBAA3927341C3600B32EB5 /* ChallengeRecommendCell.swift */; };
-		0DBBAA3D27341C3600B32EB5 /* ChallengeCategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBBAA3A27341C3600B32EB5 /* ChallengeCategoryCell.swift */; };
-		0DBBAA3E27341C3600B32EB5 /* ChallengeHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBBAA3B27341C3600B32EB5 /* ChallengeHeader.swift */; };
+		0DBBAA3727341C1600B32EB5 /* ChallengeCollectionViewLayouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBBAA3627341C1600B32EB5 /* ChallengeCollectionViewLayouts.swift */; };
+		0DBBAA3C27341C3600B32EB5 /* ChallengeRecommendCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBBAA3927341C3600B32EB5 /* ChallengeRecommendCollectionViewCell.swift */; };
+		0DBBAA3D27341C3600B32EB5 /* ChallengeCategoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBBAA3A27341C3600B32EB5 /* ChallengeCategoryCollectionViewCell.swift */; };
+		0DBBAA3E27341C3600B32EB5 /* ChallengeCollectionViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBBAA3B27341C3600B32EB5 /* ChallengeCollectionViewHeader.swift */; };
 		0DC38F44273A3B9900331C25 /* SearchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC38F43273A3B9800331C25 /* SearchCoordinator.swift */; };
 		0DC38F51273B684300331C25 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC38F50273B684300331C25 /* SearchViewModel.swift */; };
 		0DC38F59273BA89000331C25 /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC38F58273BA89000331C25 /* UIImage+Extensions.swift */; };
@@ -92,8 +92,8 @@
 		E9493DC1273A4E5B0095CF6D /* ChallengeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9493DC0273A4E5B0095CF6D /* ChallengeRepository.swift */; };
 		E9493DC3273A5D8B0095CF6D /* SearchCollectionViewLayouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9493DC2273A5D8B0095CF6D /* SearchCollectionViewLayouts.swift */; };
 		E9493DC6273A5E9D0095CF6D /* ChallengeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9493DC5273A5E9D0095CF6D /* ChallengeCollectionViewCell.swift */; };
-		E9493DC8273A70280095CF6D /* SearchPopularKeywordCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9493DC7273A70280095CF6D /* SearchPopularKeywordCell.swift */; };
-		E9493DCC273A75220095CF6D /* SearchHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9493DCB273A75220095CF6D /* SearchHeader.swift */; };
+		E9493DC8273A70280095CF6D /* SearchPopularKeywordCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9493DC7273A70280095CF6D /* SearchPopularKeywordCollectionViewCell.swift */; };
+		E9493DCC273A75220095CF6D /* SearchCollectionViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9493DCB273A75220095CF6D /* SearchCollectionViewHeader.swift */; };
 		E94B497227390FD300708D7B /* CategoryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E94B497127390FD300708D7B /* CategoryButton.swift */; };
 		E94B4974273910F400708D7B /* ChallengeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E94B4973273910F400708D7B /* ChallengeViewModel.swift */; };
 		E94B49762739118B00708D7B /* Challenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = E94B49752739118B00708D7B /* Challenge.swift */; };
@@ -171,10 +171,10 @@
 		0D053E4F2746490A0042DAF2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		0D053E512746491E0042DAF2 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		0D053E58274654390042DAF2 /* String+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
-		0DBBAA3627341C1600B32EB5 /* CollectionViewLayouts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewLayouts.swift; sourceTree = "<group>"; };
-		0DBBAA3927341C3600B32EB5 /* ChallengeRecommendCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChallengeRecommendCell.swift; sourceTree = "<group>"; };
-		0DBBAA3A27341C3600B32EB5 /* ChallengeCategoryCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChallengeCategoryCell.swift; sourceTree = "<group>"; };
-		0DBBAA3B27341C3600B32EB5 /* ChallengeHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChallengeHeader.swift; sourceTree = "<group>"; };
+		0DBBAA3627341C1600B32EB5 /* ChallengeCollectionViewLayouts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeCollectionViewLayouts.swift; sourceTree = "<group>"; };
+		0DBBAA3927341C3600B32EB5 /* ChallengeRecommendCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChallengeRecommendCollectionViewCell.swift; sourceTree = "<group>"; };
+		0DBBAA3A27341C3600B32EB5 /* ChallengeCategoryCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChallengeCategoryCollectionViewCell.swift; sourceTree = "<group>"; };
+		0DBBAA3B27341C3600B32EB5 /* ChallengeCollectionViewHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChallengeCollectionViewHeader.swift; sourceTree = "<group>"; };
 		0DC38F43273A3B9800331C25 /* SearchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCoordinator.swift; sourceTree = "<group>"; };
 		0DC38F50273B684300331C25 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		0DC38F58273BA89000331C25 /* UIImage+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
@@ -256,8 +256,8 @@
 		E9493DC0273A4E5B0095CF6D /* ChallengeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeRepository.swift; sourceTree = "<group>"; };
 		E9493DC2273A5D8B0095CF6D /* SearchCollectionViewLayouts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCollectionViewLayouts.swift; sourceTree = "<group>"; };
 		E9493DC5273A5E9D0095CF6D /* ChallengeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeCollectionViewCell.swift; sourceTree = "<group>"; };
-		E9493DC7273A70280095CF6D /* SearchPopularKeywordCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPopularKeywordCell.swift; sourceTree = "<group>"; };
-		E9493DCB273A75220095CF6D /* SearchHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHeader.swift; sourceTree = "<group>"; };
+		E9493DC7273A70280095CF6D /* SearchPopularKeywordCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPopularKeywordCollectionViewCell.swift; sourceTree = "<group>"; };
+		E9493DCB273A75220095CF6D /* SearchCollectionViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCollectionViewHeader.swift; sourceTree = "<group>"; };
 		E94B497127390FD300708D7B /* CategoryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryButton.swift; sourceTree = "<group>"; };
 		E94B4973273910F400708D7B /* ChallengeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeViewModel.swift; sourceTree = "<group>"; };
 		E94B49752739118B00708D7B /* Challenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Challenge.swift; sourceTree = "<group>"; };
@@ -331,9 +331,9 @@
 		0DBBAA3827341C3600B32EB5 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
-				0DBBAA3B27341C3600B32EB5 /* ChallengeHeader.swift */,
-				0DBBAA3927341C3600B32EB5 /* ChallengeRecommendCell.swift */,
-				0DBBAA3A27341C3600B32EB5 /* ChallengeCategoryCell.swift */,
+				0DBBAA3B27341C3600B32EB5 /* ChallengeCollectionViewHeader.swift */,
+				0DBBAA3927341C3600B32EB5 /* ChallengeRecommendCollectionViewCell.swift */,
+				0DBBAA3A27341C3600B32EB5 /* ChallengeCategoryCollectionViewCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -457,7 +457,7 @@
 		446A071F2741F611009F8D98 /* Layouts */ = {
 			isa = PBXGroup;
 			children = (
-				0DBBAA3627341C1600B32EB5 /* CollectionViewLayouts.swift */,
+				0DBBAA3627341C1600B32EB5 /* ChallengeCollectionViewLayouts.swift */,
 			);
 			path = Layouts;
 			sourceTree = "<group>";
@@ -574,8 +574,8 @@
 		E9493DC4273A5E630095CF6D /* Cells */ = {
 			isa = PBXGroup;
 			children = (
-				E9493DCB273A75220095CF6D /* SearchHeader.swift */,
-				E9493DC7273A70280095CF6D /* SearchPopularKeywordCell.swift */,
+				E9493DCB273A75220095CF6D /* SearchCollectionViewHeader.swift */,
+				E9493DC7273A70280095CF6D /* SearchPopularKeywordCollectionViewCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -1058,12 +1058,12 @@
 				441CEE11273A332D006C261F /* CreateCategoryView.swift in Sources */,
 				1483873C2743F2FF00731F98 /* ParticipantButton.swift in Sources */,
 				E9B1298227336EE50072D254 /* TodayRoutine.swift in Sources */,
-				0DBBAA3727341C1600B32EB5 /* CollectionViewLayouts.swift in Sources */,
+				0DBBAA3727341C1600B32EB5 /* ChallengeCollectionViewLayouts.swift in Sources */,
 				0DD1631C27312AC700DC5970 /* CalendarHeader.swift in Sources */,
-				E9493DCC273A75220095CF6D /* SearchHeader.swift in Sources */,
+				E9493DCC273A75220095CF6D /* SearchCollectionViewHeader.swift in Sources */,
 				1497CF572739215C00296F9E /* UserCreateUsecase.swift in Sources */,
 				E9753900273220F6004358C5 /* User.swift in Sources */,
-				0DBBAA3C27341C3600B32EB5 /* ChallengeRecommendCell.swift in Sources */,
+				0DBBAA3C27341C3600B32EB5 /* ChallengeRecommendCollectionViewCell.swift in Sources */,
 				E9493DC3273A5D8B0095CF6D /* SearchCollectionViewLayouts.swift in Sources */,
 				0DE0339A274355700026F502 /* ManageCollectionViewLayouts.swift in Sources */,
 				E9797CA42730FFB500A14A0F /* AppCoordinator.swift in Sources */,
@@ -1125,20 +1125,20 @@
 				E94B49762739118B00708D7B /* Challenge.swift in Sources */,
 				0DE03398274329BA0026F502 /* Calendar.swift in Sources */,
 				148387382743817F00731F98 /* InformationView.swift in Sources */,
-				0DBBAA3D27341C3600B32EB5 /* ChallengeCategoryCell.swift in Sources */,
+				0DBBAA3D27341C3600B32EB5 /* ChallengeCategoryCollectionViewCell.swift in Sources */,
 				E937044227434D4700D82B1D /* AuthMethodView.swift in Sources */,
 				0DC38F44273A3B9900331C25 /* SearchCoordinator.swift in Sources */,
 				E901EFEA27453F2000B14847 /* ChallengeAuthCreateUsecase.swift in Sources */,
 				E93704492743B2F800D82B1D /* AuthViewModel.swift in Sources */,
 				E9797CA22730FFAD00A14A0F /* TabBarCoordinator.swift in Sources */,
-				E9493DC8273A70280095CF6D /* SearchPopularKeywordCell.swift in Sources */,
+				E9493DC8273A70280095CF6D /* SearchPopularKeywordCollectionViewCell.swift in Sources */,
 				14AFD0FA2746211F00011CC1 /* ChallengeAuthFetchUsecase.swift in Sources */,
 				441CEE17273A33CD006C261F /* CreateIntroductionView.swift in Sources */,
 				E99474502736D54C0054A631 /* DetailCoordinator.swift in Sources */,
 				145F5324273FAF95000700A5 /* ChallengeUpdateUsecase.swift in Sources */,
 				E937044427434D6300D82B1D /* PreviewView.swift in Sources */,
 				E9797CBB27310E1000A14A0F /* ChallengeCoordinator.swift in Sources */,
-				0DBBAA3E27341C3600B32EB5 /* ChallengeHeader.swift in Sources */,
+				0DBBAA3E27341C3600B32EB5 /* ChallengeCollectionViewHeader.swift in Sources */,
 				E9797CB92731094900A14A0F /* AuthViewController.swift in Sources */,
 				E9797CB1273107A200A14A0F /* DetailViewController.swift in Sources */,
 				1497CF4C2739078700296F9E /* UserNameFactory.swift in Sources */,

--- a/Routinus/Routinus/Presentation/Challenge/Cells/ChallengeCategoryCollectionViewCell.swift
+++ b/Routinus/Routinus/Presentation/Challenge/Cells/ChallengeCategoryCollectionViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  ChallengeCategoryCell.swift
+//  ChallengeCategoryCollectionViewCell.swift
 //  Routinus
 //
 //  Created by 김민서 on 2021/11/04.
@@ -7,8 +7,8 @@
 
 import UIKit
 
-final class ChallengeCategoryCell: UICollectionViewCell {
-    static let identifier = "categoryCell"
+final class ChallengeCategoryCollectionViewCell: UICollectionViewCell {
+    static let identifier = "ChallengeCategoryCollectionViewCell"
     weak var delegate: ChallengeCategoryCellDelegate?
 
     private lazy var yStackView: UIStackView = {

--- a/Routinus/Routinus/Presentation/Challenge/Cells/ChallengeCollectionViewHeader.swift
+++ b/Routinus/Routinus/Presentation/Challenge/Cells/ChallengeCollectionViewHeader.swift
@@ -1,5 +1,5 @@
 //
-//  ChallengeHeader.swift
+//  ChallengeCollectionViewHeader.swift
 //  Routinus
 //
 //  Created by 김민서 on 2021/11/04.
@@ -7,8 +7,8 @@
 
 import UIKit
 
-final class ChallengeHeader: UICollectionReusableView {
-    static let identifier = "ChallengeHeader"
+final class ChallengeCollectionViewHeader: UICollectionReusableView {
+    static let identifier = "ChallengeCollectionViewHeader"
 
     let label: UILabel = {
         let label = UILabel()

--- a/Routinus/Routinus/Presentation/Challenge/Cells/ChallengeRecommendCollectionViewCell.swift
+++ b/Routinus/Routinus/Presentation/Challenge/Cells/ChallengeRecommendCollectionViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  ChallengeRecommendCell.swift
+//  ChallengeRecommendCollectionViewCell.swift
 //  Routinus
 //
 //  Created by 김민서 on 2021/11/04.
@@ -7,8 +7,8 @@
 
 import UIKit
 
-final class ChallengeRecommendCell: UICollectionViewCell {
-    static let identifier = "recommendCell"
+final class ChallengeRecommendCollectionViewCell: UICollectionViewCell {
+    static let identifier = "ChallengeRecommendCollectionViewCell"
 
     private lazy var titleLabel: UILabel = {
         let label = UILabel()

--- a/Routinus/Routinus/Presentation/Challenge/ChallengeViewController.swift
+++ b/Routinus/Routinus/Presentation/Challenge/ChallengeViewController.swift
@@ -49,13 +49,13 @@ final class ChallengeViewController: UIViewController {
 
         collectionView.showsVerticalScrollIndicator = false
 
-        collectionView.register(ChallengeHeader.self,
+        collectionView.register(ChallengeCollectionViewHeader.self,
                                 forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
-                                withReuseIdentifier: ChallengeHeader.identifier)
-        collectionView.register(ChallengeRecommendCell.self,
-                                forCellWithReuseIdentifier: ChallengeRecommendCell.identifier)
-        collectionView.register(ChallengeCategoryCell.self,
-                                forCellWithReuseIdentifier: ChallengeCategoryCell.identifier)
+                                withReuseIdentifier: ChallengeCollectionViewHeader.identifier)
+        collectionView.register(ChallengeRecommendCollectionViewCell.self,
+                                forCellWithReuseIdentifier: ChallengeRecommendCollectionViewCell.identifier)
+        collectionView.register(ChallengeCategoryCollectionViewCell.self,
+                                forCellWithReuseIdentifier: ChallengeCategoryCollectionViewCell.identifier)
 
         return collectionView
     }()
@@ -94,14 +94,14 @@ extension ChallengeViewController {
         let dataSource = DataSource(collectionView: self.collectionView) { collectionView, indexPath, content in
             switch content {
             case .recommend(let recommendChallenge):
-                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ChallengeRecommendCell.identifier,
-                                                              for: indexPath) as? ChallengeRecommendCell
+                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ChallengeRecommendCollectionViewCell.identifier,
+                                                              for: indexPath) as? ChallengeRecommendCollectionViewCell
                 cell?.configureViews(recommendChallenge: recommendChallenge)
                 return cell
 
             case .category:
-                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ChallengeCategoryCell.identifier,
-                                                              for: indexPath) as? ChallengeCategoryCell
+                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ChallengeCategoryCollectionViewCell.identifier,
+                                                              for: indexPath) as? ChallengeCategoryCollectionViewCell
                 cell?.delegate = self
                 cell?.configureViews()
                 return cell
@@ -119,8 +119,8 @@ extension ChallengeViewController {
 
             let view = collectionView.dequeueReusableSupplementaryView(
                         ofKind: kind,
-                        withReuseIdentifier: ChallengeHeader.identifier,
-                        for: indexPath) as? ChallengeHeader
+                        withReuseIdentifier: ChallengeCollectionViewHeader.identifier,
+                        for: indexPath) as? ChallengeCollectionViewHeader
             let section = self.dataSource.snapshot().sectionIdentifiers[indexPath.section]
 
             view?.title = section.title
@@ -182,7 +182,7 @@ extension ChallengeViewController {
 
     static func createLayout() -> UICollectionViewCompositionalLayout {
         return UICollectionViewCompositionalLayout { (sectionNumber, _) -> NSCollectionLayoutSection? in
-            let layout = CollectionViewLayouts()
+            let layout = ChallengeCollectionViewLayouts()
             return layout.section(at: sectionNumber)
         }
     }

--- a/Routinus/Routinus/Presentation/Challenge/Layouts/ChallengeCollectionViewLayouts.swift
+++ b/Routinus/Routinus/Presentation/Challenge/Layouts/ChallengeCollectionViewLayouts.swift
@@ -1,5 +1,5 @@
 //
-//  CollectionViewLayouts.swift
+//  ChallengeCollectionViewLayouts.swift
 //  Routinus
 //
 //  Created by 김민서 on 2021/11/04.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class CollectionViewLayouts {
+final class ChallengeCollectionViewLayouts {
     private var recommendLayout: NSCollectionLayoutSection {
         let smallWidth = UIScreen.main.bounds.width <= 350
         let offset = smallWidth ? 15.0 : 25.0

--- a/Routinus/Routinus/Presentation/Search/Cells/SearchCollectionViewHeader.swift
+++ b/Routinus/Routinus/Presentation/Search/Cells/SearchCollectionViewHeader.swift
@@ -1,5 +1,5 @@
 //
-//  SearchHeader.swift
+//  SearchCollectionViewHeader.swift
 //  Routinus
 //
 //  Created by 박상우 on 2021/11/09.
@@ -7,8 +7,8 @@
 
 import UIKit
 
-final class SearchHeader: UICollectionReusableView {
-    static let identifier = "SearchHeader"
+final class SearchCollectionViewHeader: UICollectionReusableView {
+    static let identifier = "SearchCollectionViewHeader"
 
     private lazy var label: UILabel = {
         let label = UILabel()

--- a/Routinus/Routinus/Presentation/Search/Cells/SearchPopularKeywordCollectionViewCell.swift
+++ b/Routinus/Routinus/Presentation/Search/Cells/SearchPopularKeywordCollectionViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  SearchPopularKeywordCell.swift
+//  SearchPopularKeywordCollectionViewCell.swift
 //  Routinus
 //
 //  Created by 박상우 on 2021/11/09.
@@ -7,8 +7,8 @@
 
 import UIKit
 
-final class SearchPopularKeywordCell: UICollectionViewCell {
-    static let identifier = "SearchPopularKeywordCell"
+final class SearchPopularKeywordCollectionViewCell: UICollectionViewCell {
+    static let identifier = "SearchPopularKeywordCollectionViewCell"
     weak var delegate: SearchPopularKeywordDelegate?
 
     private lazy var popularKeywordButton: PopularKeywordButton = {

--- a/Routinus/Routinus/Presentation/Search/SearchViewController.swift
+++ b/Routinus/Routinus/Presentation/Search/SearchViewController.swift
@@ -42,11 +42,11 @@ final class SearchViewController: UIViewController {
 
         collectionView.showsVerticalScrollIndicator = false
 
-        collectionView.register(SearchHeader.self,
+        collectionView.register(SearchCollectionViewHeader.self,
                                 forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
-                                withReuseIdentifier: SearchHeader.identifier)
-        collectionView.register(SearchPopularKeywordCell.self,
-                                forCellWithReuseIdentifier: SearchPopularKeywordCell.identifier)
+                                withReuseIdentifier: SearchCollectionViewHeader.identifier)
+        collectionView.register(SearchPopularKeywordCollectionViewCell.self,
+                                forCellWithReuseIdentifier: SearchPopularKeywordCollectionViewCell.identifier)
         collectionView.register(ChallengeCollectionViewCell.self,
                                 forCellWithReuseIdentifier: ChallengeCollectionViewCell.identifier)
 
@@ -79,8 +79,8 @@ extension SearchViewController {
         let dataSource = DataSource(collectionView: self.collectionView) { collectionView, indexPath, content in
             switch content {
             case .popularSearchKeyword(let keyword):
-                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SearchPopularKeywordCell.identifier,
-                                                              for: indexPath) as? SearchPopularKeywordCell
+                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SearchPopularKeywordCollectionViewCell.identifier,
+                                                              for: indexPath) as? SearchPopularKeywordCollectionViewCell
                 cell?.configureViews(keyword: keyword)
                 cell?.delegate = self
                 return cell
@@ -113,8 +113,8 @@ extension SearchViewController {
 
             let view = collectionView.dequeueReusableSupplementaryView(
                         ofKind: kind,
-                        withReuseIdentifier: SearchHeader.identifier,
-                        for: indexPath) as? SearchHeader
+                        withReuseIdentifier: SearchCollectionViewHeader.identifier,
+                        for: indexPath) as? SearchCollectionViewHeader
             let section = self.dataSource.snapshot().sectionIdentifiers[indexPath.section]
 
             view?.title = section.title


### PR DESCRIPTION
## 작업 내용

1. 각 header와 cell이 collectionView인지 tableView인지 명시하도록 네이밍 수정하였습니다.
    - ex) `SearchPopularKeywordCell.swift` → `SearchPopularKeywordCollectionViewCell.swift`
2. `challenge` 디렉토리에 있던 `CollectionViewLayouts.swift`를 `ChallengeCollectionViewLayouts.swift`로 이름 수정했습니다.
3. `common` 디렉토리 상단으로 옮겼습니다. (`home` 위로)