### PR TITLE
[인증 화면] autolayout -> UIView extension 변경 및 continuityDay 업데이트

### DIFF
--- a/Routinus/Routinus.xcodeproj/project.pbxproj
+++ b/Routinus/Routinus.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		E9A7943D2746125E00731DEB /* ParticipationUpdateUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A7943C2746125E00731DEB /* ParticipationUpdateUsecase.swift */; };
 		E9A7943F274618AB00731DEB /* AchievementUpdateUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A7943E274618AB00731DEB /* AchievementUpdateUsecase.swift */; };
 		E9B1298227336EE50072D254 /* TodayRoutine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B1298127336EE50072D254 /* TodayRoutine.swift */; };
+		E9B87CC6274950FC00D7C0D2 /* UserUpdateUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B87CC5274950FC00D7C0D2 /* UserUpdateUsecase.swift */; };
 		E9D0CAE427395AC100F66390 /* ChallengeFetchUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D0CAE327395AC100F66390 /* ChallengeFetchUsecase.swift */; };
 		E9D0CAE8273978C600F66390 /* ChallengeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D0CAE7273978C600F66390 /* ChallengeDTO.swift */; };
 		E9E9D1E8273BA83800F9CCBB /* PopularKeywordButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E9D1E7273BA83800F9CCBB /* PopularKeywordButton.swift */; };
@@ -297,6 +298,7 @@
 		E9A7943C2746125E00731DEB /* ParticipationUpdateUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipationUpdateUsecase.swift; sourceTree = "<group>"; };
 		E9A7943E274618AB00731DEB /* AchievementUpdateUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementUpdateUsecase.swift; sourceTree = "<group>"; };
 		E9B1298127336EE50072D254 /* TodayRoutine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayRoutine.swift; sourceTree = "<group>"; };
+		E9B87CC5274950FC00D7C0D2 /* UserUpdateUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdateUsecase.swift; sourceTree = "<group>"; };
 		E9D0CAE327395AC100F66390 /* ChallengeFetchUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeFetchUsecase.swift; sourceTree = "<group>"; };
 		E9D0CAE7273978C600F66390 /* ChallengeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeDTO.swift; sourceTree = "<group>"; };
 		E9E9D1E7273BA83800F9CCBB /* PopularKeywordButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularKeywordButton.swift; sourceTree = "<group>"; };
@@ -635,6 +637,7 @@
 				145F5323273FAF95000700A5 /* ChallengeUpdateUsecase.swift */,
 				E901EFDD2744CBDE00B14847 /* UserFetchUsecase.swift */,
 				1497CF562739215C00296F9E /* UserCreateUsecase.swift */,
+				E9B87CC5274950FC00D7C0D2 /* UserUpdateUsecase.swift */,
 				E901EFD92744CAA800B14847 /* TodayRoutineFetchUsecase.swift */,
 				E901EFDF2744CC4F00B14847 /* AchievementFetchUsecase.swift */,
 				E9A7943E274618AB00731DEB /* AchievementUpdateUsecase.swift */,
@@ -1092,6 +1095,7 @@
 				1497CF572739215C00296F9E /* UserCreateUsecase.swift in Sources */,
 				E9753900273220F6004358C5 /* User.swift in Sources */,
 				0DBBAA3C27341C3600B32EB5 /* ChallengeRecommendCollectionViewCell.swift in Sources */,
+				E9B87CC6274950FC00D7C0D2 /* UserUpdateUsecase.swift in Sources */,
 				E9493DC3273A5D8B0095CF6D /* SearchCollectionViewLayouts.swift in Sources */,
 				0DE0339A274355700026F502 /* ManageCollectionViewLayouts.swift in Sources */,
 				E9797CA42730FFB500A14A0F /* AppCoordinator.swift in Sources */,

--- a/Routinus/Routinus/Application/Coordinator/AuthCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/AuthCoordinator.swift
@@ -25,13 +25,15 @@ final class AuthCoordinator: RoutinusCoordinator {
         let challengeAuthCreateUsecase = ChallengeAuthCreateUsecase(repository: repository)
         let participationUpdateUsecase = ParticipationUpdateUsecase(repository: repository)
         let achievementUpdateUsecase = AchievementUpdateUsecase(repository: repository)
+        let userUpdateUsecase = UserUpdateUsecase(repository: repository)
         let authViewModel = AuthViewModel(challengeID: challengeID,
                                           challengeFetchUsecase: challengeFetchUsecase,
                                           imageFetchUsecase: imageFetchUsecase,
                                           imageSaveUsecase: imageSaveUsecase,
                                           challengeAuthCreateUsecase: challengeAuthCreateUsecase,
                                           participationUpdateUsecase: participationUpdateUsecase,
-                                          achievementUpdateUsecase: achievementUpdateUsecase)
+                                          achievementUpdateUsecase: achievementUpdateUsecase,
+                                          userUpdateUsecase: userUpdateUsecase)
         let authViewController = AuthViewController(viewModel: authViewModel)
         authViewController.hidesBottomBarWhenPushed = true
         self.navigationController.pushViewController(authViewController, animated: true)

--- a/Routinus/Routinus/Data/UserRepository.swift
+++ b/Routinus/Routinus/Data/UserRepository.swift
@@ -15,6 +15,7 @@ protocol UserRepository {
               name: String)
     func fetchUser(by id: String,
                    completion: ((User) -> Void)?)
+    func updateContinuityDay(by id: String)
 }
 
 extension RoutinusRepository: UserRepository {
@@ -36,5 +37,10 @@ extension RoutinusRepository: UserRepository {
         RoutinusDatabase.user(of: id) { dto in
             completion?(User(userDTO: dto))
         }
+    }
+
+    func updateContinuityDay(by id: String) {
+        RoutinusDatabase.updateContinuityDay(of: id,
+                                             completion: nil)
     }
 }

--- a/Routinus/Routinus/Domain/Usecase/UserUpdateUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/UserUpdateUsecase.swift
@@ -1,0 +1,25 @@
+//
+//  UserUpdateUsecase.swift
+//  Routinus
+//
+//  Created by 박상우 on 2021/11/21.
+//
+
+import Foundation
+
+protocol UserUpdatableUsecase {
+    func updateContinuityDay()
+}
+
+struct UserUpdateUsecase: UserUpdatableUsecase {
+    var repository: UserRepository
+
+    init(repository: UserRepository) {
+        self.repository = repository
+    }
+
+    func updateContinuityDay() {
+        guard let userID = RoutinusRepository.userID() else { return }
+        self.repository.updateContinuityDay(by: userID)
+    }
+}

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -53,10 +53,9 @@ extension AuthViewController {
         self.configureNavigationBar()
 
         self.view.addSubview(scrollView)
-        self.scrollView.translatesAutoresizingMaskIntoConstraints = false
-        self.scrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor).isActive = true
-        self.scrollView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor).isActive = true
-        self.scrollView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+        self.scrollView.anchor(left: self.view.safeAreaLayoutGuide.leftAnchor,
+                               right: self.view.safeAreaLayoutGuide.rightAnchor,
+                               top: self.view.safeAreaLayoutGuide.topAnchor)
 
         self.view.addSubview(authView)
         authView.anchor(horizontal: authView.superview,
@@ -70,12 +69,11 @@ extension AuthViewController {
                           bottom: authButton.superview?.bottomAnchor, paddingBottom: 30)
 
         self.scrollView.addSubview(stackView)
-        self.stackView.translatesAutoresizingMaskIntoConstraints = false
-        self.stackView.topAnchor.constraint(equalTo: self.scrollView.topAnchor).isActive = true
-        self.stackView.bottomAnchor.constraint(equalTo: self.scrollView.bottomAnchor, constant: -20).isActive = true
-        self.stackView.leadingAnchor.constraint(equalTo: self.scrollView.leadingAnchor).isActive = true
-        self.stackView.trailingAnchor.constraint(equalTo: self.scrollView.trailingAnchor).isActive = true
-        self.stackView.centerXAnchor.constraint(equalTo: self.scrollView.centerXAnchor).isActive = true
+        self.stackView.anchor(left: self.scrollView.leftAnchor,
+                              right: self.scrollView.rightAnchor,
+                              centerX: self.scrollView.centerXAnchor,
+                              top: self.scrollView.topAnchor,
+                              bottom: self.scrollView.bottomAnchor, paddingBottom: 20)
 
         self.stackView.addArrangedSubview(authMethodView)
 

--- a/Routinus/Routinus/Presentation/Auth/AuthViewModel.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewModel.swift
@@ -36,6 +36,7 @@ class AuthViewModel: AuthViewModelIO {
     var challengeAuthCreateUsecase: ChallengeAuthCreatableUsecase
     var participationUpdateUsecase: ParticipationUpdatableUsecase
     var achievementUpdateUsecase: AchievementUpdatableUsecase
+    var userUpdateUsecase: UserUpdatableUsecase
 
     private var challengeID: String
     private var userAuthImageURL: String
@@ -47,7 +48,8 @@ class AuthViewModel: AuthViewModelIO {
          imageSaveUsecase: ImageSavableUsecase,
          challengeAuthCreateUsecase: ChallengeAuthCreatableUsecase,
          participationUpdateUsecase: ParticipationUpdatableUsecase,
-         achievementUpdateUsecase: AchievementUpdatableUsecase) {
+         achievementUpdateUsecase: AchievementUpdatableUsecase,
+         userUpdateUsecase: UserUpdatableUsecase) {
         self.challengeID = challengeID
         self.challengeFetchUsecase = challengeFetchUsecase
         self.imageFetchUsecase = imageFetchUsecase
@@ -55,6 +57,7 @@ class AuthViewModel: AuthViewModelIO {
         self.challengeAuthCreateUsecase = challengeAuthCreateUsecase
         self.participationUpdateUsecase = participationUpdateUsecase
         self.achievementUpdateUsecase = achievementUpdateUsecase
+        self.userUpdateUsecase = userUpdateUsecase
         self.userAuthImageURL = ""
         self.userAuthThumbnailImageURL = ""
         self.fetchChallenge(challengeID: challengeID)
@@ -72,6 +75,7 @@ extension AuthViewModel {
                                                             userAuthThumbnailImageURL: userAuthThumbnailImageURL)
         self.participationUpdateUsecase.updateParticipationAuthCount(challengeID: challengeID)
         self.achievementUpdateUsecase.updateAchievementCount()
+        self.userUpdateUsecase.updateContinuityDay()
     }
 
     func update(userAuthImageURL: String?) {

--- a/Routinus/Routinus/Presentation/Auth/Subviews/AuthButton.swift
+++ b/Routinus/Routinus/Presentation/Auth/Subviews/AuthButton.swift
@@ -31,7 +31,7 @@ final class AuthButton: UIButton {
     @objc func didTappedAuthButton() {
         delegate?.didTappedAuthButton()
     }
-    
+
     func configureEnabled(isEnabled: Bool) {
         self.isEnabled = isEnabled
         self.alpha = isEnabled ? 1 : 0.5

--- a/Routinus/RoutinusDatabase/DTO/UserDTO.swift
+++ b/Routinus/RoutinusDatabase/DTO/UserDTO.swift
@@ -13,6 +13,23 @@ public struct UserDTO: Codable {
     init() {
         self.document = nil
     }
+
+    public init(id: String,
+                name: String,
+                grade: Int,
+                continuityDay: Int,
+                userImageCategoryID: String) {
+        let field = UserFields(id: StringField(stringValue: id),
+                               name: StringField(stringValue: name),
+                               grade: IntegerField(integerValue: "\(grade)"),
+                               continuityDay: IntegerField(integerValue: "\(continuityDay)"),
+                               userImageCategoryID: StringField(stringValue: userImageCategoryID))
+        self.document = Fields(name: nil, fields: field)
+    }
+
+    var documentID: String? {
+        return self.document?.name?.components(separatedBy: "/").last
+    }
 }
 
 public struct UserFields: Codable {

--- a/Routinus/RoutinusDatabase/DTO/UserDTO.swift
+++ b/Routinus/RoutinusDatabase/DTO/UserDTO.swift
@@ -18,12 +18,14 @@ public struct UserDTO: Codable {
                 name: String,
                 grade: Int,
                 continuityDay: Int,
-                userImageCategoryID: String) {
+                userImageCategoryID: String,
+                lastAuthDay: String) {
         let field = UserFields(id: StringField(stringValue: id),
                                name: StringField(stringValue: name),
                                grade: IntegerField(integerValue: "\(grade)"),
                                continuityDay: IntegerField(integerValue: "\(continuityDay)"),
-                               userImageCategoryID: StringField(stringValue: userImageCategoryID))
+                               userImageCategoryID: StringField(stringValue: userImageCategoryID),
+                               lastAuthDay: StringField(stringValue: lastAuthDay))
         self.document = Fields(name: nil, fields: field)
     }
 
@@ -38,10 +40,12 @@ public struct UserFields: Codable {
     public let grade: IntegerField
     public let continuityDay: IntegerField
     public let userImageCategoryID: StringField
+    public let lastAuthDay: StringField
 
     public enum CodingKeys: String, CodingKey {
         case id, name, grade
         case continuityDay = "continuity_day"
         case userImageCategoryID = "user_image_category_id"
+        case lastAuthDay = "last_auth_day"
     }
 }

--- a/Routinus/RoutinusDatabase/Query/UserQuery.swift
+++ b/Routinus/RoutinusDatabase/Query/UserQuery.swift
@@ -40,4 +40,14 @@ internal enum UserQuery {
         }
         """.data(using: .utf8)
     }
+
+    internal static func update(document: UserFields) -> Data? {
+        return """
+        {
+            "fields": {
+                "continuity_day": { "integerValue": "\(document.continuityDay.integerValue)" }
+            }
+        }
+        """.data(using: .utf8)
+    }
 }

--- a/Routinus/RoutinusDatabase/Query/UserQuery.swift
+++ b/Routinus/RoutinusDatabase/Query/UserQuery.swift
@@ -36,6 +36,7 @@ internal enum UserQuery {
                 "grade": { "integerValue": "0" },
                 "continuity_day": { "integerValue": "0" },
                 "user_image_category_id": { "stringValue": "0" }
+                "last_auth_day": { "stringValue": "0" }
             }
         }
         """.data(using: .utf8)
@@ -45,7 +46,8 @@ internal enum UserQuery {
         return """
         {
             "fields": {
-                "continuity_day": { "integerValue": "\(document.continuityDay.integerValue)" }
+                "continuity_day": { "integerValue": "\(document.continuityDay.integerValue)" },
+                "last_auth_day": { "stringValue": "\(document.lastAuthDay.stringValue)" }
             }
         }
         """.data(using: .utf8)

--- a/Routinus/RoutinusDatabase/RoutinusDatabase.swift
+++ b/Routinus/RoutinusDatabase/RoutinusDatabase.swift
@@ -511,6 +511,43 @@ public enum RoutinusDatabase {
             completion?()
         }
     }
+    
+    public static func updateContinuityDay(of id: String,
+                                           completion: (() -> Void)?) {
+        user(of: id) { dto in
+            guard let document = dto.document,
+                  let grade = Int(document.fields.grade.integerValue),
+                  let continuityDay = Int(document.fields.continuityDay.integerValue) else { return }
+
+            let name = document.fields.name.stringValue
+            let userImageCategoryID = document.fields.userImageCategoryID.stringValue
+            
+            let userDTO = UserDTO(id: id,
+                                  name: name,
+                                  grade: grade,
+                                  continuityDay: continuityDay + 1,
+                                  userImageCategoryID: userImageCategoryID)
+                
+
+            guard let userField = userDTO.document?.fields else { return }
+            let documentID = dto.documentID ?? ""
+            var urlComponent = URLComponents(string: "\(firestoreURL)/user/\(documentID)?")
+            let queryItems = [
+                URLQueryItem(name: "updateMask.fieldPaths", value: "continuity_day")
+            ]
+            urlComponent?.queryItems = queryItems
+
+            guard let url = urlComponent?.url else { return }
+            var request = URLRequest(url: url)
+            request.addValue("text/plain", forHTTPHeaderField: "Content-Type")
+            request.httpMethod = HTTPMethod.patch.rawValue
+            request.httpBody = UserQuery.update(document: userField)
+
+            URLSession.shared.dataTask(with: request) { _, _, _ in
+                completion?()
+            }.resume()
+        }
+    }
 
     public static func updateChallenge(challengeDTO: ChallengeDTO,
                                        completion: (() -> Void)?) {

--- a/Routinus/RoutinusDatabase/RoutinusDatabase.swift
+++ b/Routinus/RoutinusDatabase/RoutinusDatabase.swift
@@ -517,7 +517,13 @@ public enum RoutinusDatabase {
         user(of: id) { dto in
             guard let document = dto.document,
                   let grade = Int(document.fields.grade.integerValue),
-                  let continuityDay = Int(document.fields.continuityDay.integerValue) else { return }
+                  let continuityDay = Int(document.fields.continuityDay.integerValue),
+                  let lastAuthDay = Int(document.fields.lastAuthDay.stringValue) else { return }
+
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyyMMdd"
+            guard let date = Int(dateFormatter.string(from: Date())),
+                  lastAuthDay < date else { return }
 
             let name = document.fields.name.stringValue
             let userImageCategoryID = document.fields.userImageCategoryID.stringValue
@@ -526,13 +532,15 @@ public enum RoutinusDatabase {
                                   name: name,
                                   grade: grade,
                                   continuityDay: continuityDay + 1,
-                                  userImageCategoryID: userImageCategoryID)
+                                  userImageCategoryID: userImageCategoryID,
+                                  lastAuthDay: "\(date)")
 
             guard let userField = userDTO.document?.fields else { return }
             let documentID = dto.documentID ?? ""
             var urlComponent = URLComponents(string: "\(firestoreURL)/user/\(documentID)?")
             let queryItems = [
-                URLQueryItem(name: "updateMask.fieldPaths", value: "continuity_day")
+                URLQueryItem(name: "updateMask.fieldPaths", value: "continuity_day"),
+                URLQueryItem(name: "updateMask.fieldPaths", value: "last_auth_day")
             ]
             urlComponent?.queryItems = queryItems
 

--- a/Routinus/RoutinusDatabase/RoutinusDatabase.swift
+++ b/Routinus/RoutinusDatabase/RoutinusDatabase.swift
@@ -511,7 +511,7 @@ public enum RoutinusDatabase {
             completion?()
         }
     }
-    
+
     public static func updateContinuityDay(of id: String,
                                            completion: (() -> Void)?) {
         user(of: id) { dto in
@@ -521,13 +521,12 @@ public enum RoutinusDatabase {
 
             let name = document.fields.name.stringValue
             let userImageCategoryID = document.fields.userImageCategoryID.stringValue
-            
+
             let userDTO = UserDTO(id: id,
                                   name: name,
                                   grade: grade,
                                   continuityDay: continuityDay + 1,
                                   userImageCategoryID: userImageCategoryID)
-                
 
             guard let userField = userDTO.document?.fields else { return }
             let documentID = dto.documentID ?? ""


### PR DESCRIPTION
## 관련 issue

#174 

## 작업 내용

- [x] AuthViewController 레이아웃코드 UIView Extension anchor 변경
- [x] 인증하기 버튼 누르면 User의 continuityday 업데이트 

## 기타 사항
저번 회의때 나온 lastAuthDay를 확인하고 인증 날짜와 lastAuthDay가 같은 날이면 continuityDay를 업데이트 하지 않고 
lastAuthDay가 인증날짜 이전이면 continuityDay를 업데이트를 하고 lastAuthDay도 업데이트하는 로직으로 구현했습니다.
lastAuthDay를 challenge_participation컬렉션에 두는걸로 회의를 했었던 것 같은데 여러챌린지를 가지고 있을 때 
유저가 해당 챌린지별 lastAuthDay기록이 아닌 유저자체의 lastAuthDay를 확인할 필요가 있어 user컬렉션에 저장하고 업데이트 하는방안으로 구현했습니다.
) lastAuthDay는 초기 user컬렉션에 insert할때는 0값으로 넣어주도록 설정해 놧습니다.
