### PR TITLE
[RoutinusImageManager] 챌린지 ID를 기준으로 캐시 삭제할 수 있도록 개선

### DIFF
--- a/Routinus/Routinus/Data/ChallengeAuthRepository.swift
+++ b/Routinus/Routinus/Data/ChallengeAuthRepository.swift
@@ -35,7 +35,7 @@ extension RoutinusRepository: ChallengeAuthRepository {
         RoutinusDatabase.insertChallengeAuth(challengeAuth: challengeAuthDTO,
                                              userAuthImageURL: userAuthImageURL,
                                              userAuthThumbnailImageURL: userAuthThumbnailImageURL) {
-            RoutinusImageManager.removeTempCachedImages()
+            RoutinusImageManager.removeCachedImages(from: "temp")
         }
     }
 

--- a/Routinus/Routinus/Data/ChallengeRepository.swift
+++ b/Routinus/Routinus/Data/ChallengeRepository.swift
@@ -125,7 +125,7 @@ extension RoutinusRepository: ChallengeRepository {
                                          thumbnailImageURL: thumbnailImageURL,
                                          authExampleImageURL: authExampleImageURL,
                                          authExampleThumbnailImageURL: authExampleThumbnailImageURL) {
-            RoutinusImageManager.removeTempCachedImages()
+            RoutinusImageManager.removeCachedImages(from: "temp")
         }
     }
 
@@ -152,7 +152,7 @@ extension RoutinusRepository: ChallengeRepository {
                                         thumbnailImageURL: thumbnailImageURL,
                                         authExampleImageURL: authExampleImageURL,
                                         authExampleThumbnailImageURL: authExampleThumbnailImageURL) {
-            RoutinusImageManager.removeTempCachedImages()
+            RoutinusImageManager.removeCachedImages(from: "temp")
         }
     }
 }

--- a/Routinus/RoutinusImageManager/RoutinusImageManager.swift
+++ b/Routinus/RoutinusImageManager/RoutinusImageManager.swift
@@ -73,14 +73,14 @@ public enum RoutinusImageManager {
                                               attributes: nil) ? url.absoluteString : nil
     }
 
-    public static func removeTempCachedImages() {
+    public static func removeCachedImages(from directory: String) {
         guard let path = NSSearchPathForDirectoriesInDomains(.cachesDirectory,
                                                              .userDomainMask,
                                                              true).first else { return }
 
         let url = URL(fileURLWithPath: path)
         let filenames = cachedFilenames()
-            .filter{ $0.hasPrefix("temp") && $0.hasSuffix(".jpeg") }
+            .filter{ $0.hasPrefix(directory) && $0.hasSuffix(".jpeg") }
 
         for filename in filenames {
             var url = url


### PR DESCRIPTION
## 작업 내용

- [x] 챌린지 ID를 기준으로 캐시 삭제할 수 있도록 개선

## 기타 사항

- 기존 removeTempCachedImages를 수정해서 챌린지 ID를 기준으로 삭제할 수 있도록 수정했습니다.

예를 들어 챌린지 ID가 `36F1EA16-4B98-4AE9-A453-DCCB9CAA1CA4`라면, 아래처럼 호출하면 됩니다.
아마 repository에서 수정 로직 진행한 이후 같이 호출하면 될겁니다 (기존 temp 삭제하는 코드 참고)

```swift
import RoutinusImageManager

let id = "36F1EA16-4B98-4AE9-A453-DCCB9CAA1CA4"
RoutinusImageManager.removeCachedImages(from: id)
```