### PR TITLE
[챌린지 추가 화면] 챌린지 update 로직 적용

### DIFF
--- a/Routinus/Routinus/Application/Coordinator/CreateCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/CreateCoordinator.swift
@@ -29,12 +29,14 @@ final class CreateCoordinator: RoutinusCoordinator {
         let challengeCreateUsecase = ChallengeCreateUsecase(repository: repository)
         let challengeUpdateUsecase = ChallengeUpdateUsecase(repository: repository)
         let challengeFetchUsecase = ChallengeFetchUsecase(repository: repository)
+        let imageFetchUsecase = ImageFetchUsecase(repository: repository)
         let imageSaveUsecase = ImageSaveUsecase(repository: repository)
 
         let createViewModel = CreateViewModel(challengeID: challengeID,
                                               challengeCreateUsecase: challengeCreateUsecase,
                                               challengeUpdateUsecase: challengeUpdateUsecase,
                                               challengeFetchUsecase: challengeFetchUsecase,
+                                              imageFetchUsecase: imageFetchUsecase,
                                               imageSaveUsecase: imageSaveUsecase)
         let createViewController = CreateViewController(with: createViewModel)
         createViewController.hidesBottomBarWhenPushed = true

--- a/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/DetailCoordinator.swift
@@ -16,6 +16,8 @@ final class DetailCoordinator: RoutinusCoordinator {
     let challengeID: String?
     let authPublisher = NotificationCenter.default.publisher(for: AuthCoordinator.confirmAuth,
                                                              object: nil)
+    let updatePublisher = NotificationCenter.default.publisher(for: CreateCoordinator.confirmCreate,
+                                                               object: nil)
 
     init(navigationController: UINavigationController, challengeID: String) {
         self.navigationController = navigationController
@@ -74,6 +76,14 @@ final class DetailCoordinator: RoutinusCoordinator {
                 detailViewModel.fetchParticipationAuthState()
             }
             .store(in: &cancellables)
+
+        self.updatePublisher
+            .receive(on: RunLoop.main)
+            .sink { _ in
+                detailViewModel.fetchChallenge()
+            }
+            .store(in: &cancellables)
+
 
         self.navigationController.pushViewController(detailViewController,
                                                      animated: true)

--- a/Routinus/Routinus/Data/ChallengeRepository.swift
+++ b/Routinus/Routinus/Data/ChallengeRepository.swift
@@ -160,7 +160,7 @@ extension RoutinusRepository: ChallengeRepository {
                                         thumbnailImageURL: thumbnailImageURL,
                                         authExampleImageURL: authExampleImageURL,
                                         authExampleThumbnailImageURL: authExampleThumbnailImageURL) {
-            RoutinusImageManager.removeCachedImages(from: "temp")
+            RoutinusImageManager.removeCachedImages(from: challenge.challengeID)
         }
     }
 }

--- a/Routinus/Routinus/Data/ChallengeRepository.swift
+++ b/Routinus/Routinus/Data/ChallengeRepository.swift
@@ -85,7 +85,15 @@ extension RoutinusRepository: ChallengeRepository {
         guard let ownerID = RoutinusRepository.userID() else { return }
         RoutinusDatabase.challenge(ownerID: ownerID,
                                    challengeID: challengeID) { dto in
-            completion(Challenge(challengeDTO: dto))
+            let imageURL = RoutinusImageManager.cachedImageURL(from: challengeID, filename: "image")
+            let thumbnailImageURL = RoutinusImageManager.cachedImageURL(from: challengeID, filename: "thumbnail_image")
+            let authExampleImageURL = RoutinusImageManager.cachedImageURL(from: challengeID, filename: "auth")
+            let authExampleThumbnailImageURL = RoutinusImageManager.cachedImageURL(from: challengeID, filename: "thumbnail_auth")
+            completion(Challenge(challengeDTO: dto,
+                                 imageURL: imageURL,
+                                 thumbnailImageURL: thumbnailImageURL,
+                                 authExampleImageURL: authExampleImageURL,
+                                 authExampleThumbnailImageURL: authExampleThumbnailImageURL))
         }
     }
 

--- a/Routinus/Routinus/Domain/Entity/Challenge.swift
+++ b/Routinus/Routinus/Domain/Entity/Challenge.swift
@@ -182,4 +182,27 @@ struct Challenge: Hashable {
         self.week = Int(document?.week.integerValue ?? "") ?? 0
         self.participantCount = Int(document?.participantCount.integerValue ?? "") ?? 0
     }
+
+    init(challengeDTO: ChallengeDTO,
+         imageURL: String,
+         thumbnailImageURL: String,
+         authExampleImageURL: String,
+         authExampleThumbnailImageURL: String) {
+        let document = challengeDTO.document?.fields
+
+        self.challengeID = document?.id.stringValue ?? ""
+        self.title = document?.title.stringValue ?? ""
+        self.introduction = document?.desc.stringValue ?? ""
+        self.category = Category.category(by: document?.categoryID.stringValue ?? "")
+        self.imageURL = imageURL
+        self.thumbnailImageURL = thumbnailImageURL
+        self.authExampleImageURL = authExampleImageURL
+        self.authExampleThumbnailImageURL = authExampleThumbnailImageURL
+        self.authMethod = document?.authMethod.stringValue ?? ""
+        self.startDate = Date(dateString: document?.startDate.stringValue ?? "")
+        self.endDate = Date(dateString: document?.endDate.stringValue ?? "")
+        self.ownerID = document?.ownerID.stringValue ?? ""
+        self.week = Int(document?.week.integerValue ?? "") ?? 0
+        self.participantCount = Int(document?.participantCount.integerValue ?? "") ?? 0
+    }
 }

--- a/Routinus/Routinus/Domain/Usecase/ChallengeUpdateUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/ChallengeUpdateUsecase.swift
@@ -27,7 +27,6 @@ struct ChallengeUpdateUsecase: ChallengeUpdatableUsecase {
     }
 
     func updateChallenge(challenge: Challenge) {
-        // TODO: Task있었는데 completion 필요 없는 것 같아서 지웠습니다 확인 바람!
         repository.update(challenge: challenge,
                           imageURL: challenge.imageURL,
                           thumbnailImageURL: challenge.thumbnailImageURL,

--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -133,6 +133,15 @@ extension CreateViewController {
 
                 self.categoryView.update(category: challenge.category)
                 self.titleView.update(title: challenge.title)
+                self.viewModel?.imageData(from: challenge.challengeID,
+                                          filename: "thumbnail_image",
+                                          completion: { data in
+                    guard let data = data else { return }
+                    guard let image = UIImage(data: data) else { return }
+                    DispatchQueue.main.async {
+                        self.imageRegisterView.setImage(image)
+                    }
+                })
             })
             .store(in: &cancellables)
     }

--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -192,7 +192,7 @@ extension CreateViewController {
 
 extension CreateViewController {
     private func presentAlert() {
-        let message = self.viewModel?.buttonType.value == .create ? "챌린지가 생성되었습니다." : "챌린지가 수정되었습니다"
+        let message = self.viewModel?.buttonType.value.confirmMessage
         let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
         let confirm = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
             guard let self = self else { return }

--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -44,7 +44,7 @@ final class CreateViewController: UIViewController {
     private lazy var authImageRegisterView = CreateAuthImageRegisterView()
     private lazy var createButton: UIButton = {
         var button = UIButton()
-        button.setTitle("생성하기", for: .normal)
+        button.setTitle(ButtonType.create.rawValue, for: .normal)
         button.setTitleColor(.black, for: .normal)
         button.titleLabel?.font = .boldSystemFont(ofSize: 20)
         button.backgroundColor = UIColor(red: 180/255, green: 231/255, blue: 160/255, alpha: 1)
@@ -109,7 +109,16 @@ extension CreateViewController {
 
     private func configureViewModel() {
         self.viewModel?.didLoadedChallenge()
-        self.viewModel?.createButtonState
+
+        self.viewModel?.buttonType
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] buttonType in
+                guard let self = self else { return }
+                self.createButton.setTitle(buttonType.rawValue, for: .normal)
+            })
+            .store(in: &cancellables)
+
+        self.viewModel?.buttonState
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isEnabled in
                 guard let self = self else { return }
@@ -140,6 +149,18 @@ extension CreateViewController {
                     guard let image = UIImage(data: data) else { return }
                     DispatchQueue.main.async {
                         self.imageRegisterView.setImage(image)
+                    }
+                })
+                //self.weekView.update(week: challenge.week)
+                //self.introductionView.update(introduction: challenge.introduction)
+                //self.authMethodView.update(authMethod: challenge.authMethod)
+                self.viewModel?.imageData(from: challenge.challengeID,
+                                          filename: "thumbnail_auth",
+                                          completion: { data in
+                    guard let data = data else { return }
+                    guard let image = UIImage(data: data) else { return }
+                    DispatchQueue.main.async {
+                        self.authImageRegisterView.setImage(image)
                     }
                 })
             })
@@ -352,6 +373,7 @@ extension CreateViewController: UIImagePickerControllerDelegate, UINavigationCon
                 viewModel?.update(authExampleImageURL: mainImageURL)
                 viewModel?.update(authExampleThumbnailImageURL: thumbnailImageURL)
                 authImageRegisterView.setImage(thumbnailImage)
+
             default:
                 break
             }

--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -124,6 +124,14 @@ extension CreateViewController {
                 self.weekView.updateEndDate(date: endDate)
             })
             .store(in: &cancellables)
+
+        self.viewModel?.challenge
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] challenge in
+                guard let self = self, let challenge = challenge else { return }
+                // 카테고리 value update
+                //self.categoryView.update(category: challenge.category)
+            })
     }
 
     private func configureDelegates() {

--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -151,9 +151,9 @@ extension CreateViewController {
                         self.imageRegisterView.setImage(image)
                     }
                 })
-                //self.weekView.update(week: challenge.week)
-                //self.introductionView.update(introduction: challenge.introduction)
-                //self.authMethodView.update(authMethod: challenge.authMethod)
+                self.weekView.update(week: challenge.week) 
+                self.introductionView.update(introduction: challenge.introduction)
+                self.authMethodView.update(authMethod: challenge.authMethod)
                 self.viewModel?.imageData(from: challenge.challengeID,
                                           filename: "thumbnail_auth",
                                           completion: { data in
@@ -194,7 +194,8 @@ extension CreateViewController {
 
 extension CreateViewController {
     private func presentAlert() {
-        let alert = UIAlertController(title: "알림", message: "챌린지가 생성되었습니다.", preferredStyle: .alert)
+        let message = self.viewModel?.buttonType.value == .create ? "챌린지가 생성되었습니다." : "챌린지가 수정되었습니다"
+        let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
         let confirm = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
             guard let self = self else { return }
             self.viewModel?.didTappedAlertConfirm()

--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -108,6 +108,7 @@ extension CreateViewController {
     }
 
     private func configureViewModel() {
+        self.viewModel?.didLoadedChallenge()
         self.viewModel?.createButtonState
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isEnabled in
@@ -129,9 +130,11 @@ extension CreateViewController {
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] challenge in
                 guard let self = self, let challenge = challenge else { return }
-                // 카테고리 value update
-                //self.categoryView.update(category: challenge.category)
+
+                self.categoryView.update(category: challenge.category)
+                self.titleView.update(title: challenge.title)
             })
+            .store(in: &cancellables)
     }
 
     private func configureDelegates() {

--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -145,8 +145,7 @@ extension CreateViewController {
                 self.viewModel?.imageData(from: challenge.challengeID,
                                           filename: "thumbnail_image",
                                           completion: { data in
-                    guard let data = data else { return }
-                    guard let image = UIImage(data: data) else { return }
+                    guard let data = data, let image = UIImage(data: data) else { return }
                     DispatchQueue.main.async {
                         self.imageRegisterView.setImage(image)
                     }
@@ -157,8 +156,7 @@ extension CreateViewController {
                 self.viewModel?.imageData(from: challenge.challengeID,
                                           filename: "thumbnail_auth",
                                           completion: { data in
-                    guard let data = data else { return }
-                    guard let image = UIImage(data: data) else { return }
+                    guard let data = data, let image = UIImage(data: data) else { return }
                     DispatchQueue.main.async {
                         self.authImageRegisterView.setImage(image)
                     }

--- a/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
@@ -223,7 +223,6 @@ extension CreateViewModel {
                                         ownerID: challenge.ownerID,
                                         week: week,
                                         participantCount: challenge.participantCount)
-        self.challenge.value = updateChallenge
         challengeUpdateUsecase.updateChallenge(challenge: updateChallenge)
     }
 

--- a/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
@@ -11,6 +11,15 @@ import Foundation
 enum ButtonType: String {
     case create = "생성하기"
     case update = "수정하기"
+
+    var confirmMessage: String {
+        switch self {
+        case .create:
+            return "챌린지가 생성되었습니다."
+        case .update:
+            return "챌린지가 수정되었습니다."
+        }
+    }
 }
 
 protocol CreateViewModelInput {

--- a/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
@@ -40,6 +40,10 @@ protocol CreateViewModelInput {
     func saveImage(to directory: String,
                    filename: String,
                    data: Data?) -> String?
+    func imageData(from directory: String,
+                   filename: String,
+                   completion: ((Data?) -> Void)?)
+    
 }
 
 protocol CreateViewModelOutput {
@@ -61,6 +65,7 @@ final class CreateViewModel: CreateViewModelIO {
     var challengeCreateUsecase: ChallengeCreatableUsecase
     var challengeUpdateUsecase: ChallengeUpdatableUsecase
     var challengeFetchUsecase: ChallengeFetchableUsecase
+    var imageFetchUsecase: ImageFetchableUsecase
     var imageSaveUsecase: ImageSavableUsecase
     var challengeID: String?
 
@@ -78,11 +83,13 @@ final class CreateViewModel: CreateViewModelIO {
          challengeCreateUsecase: ChallengeCreatableUsecase,
          challengeUpdateUsecase: ChallengeUpdatableUsecase,
          challengeFetchUsecase: ChallengeFetchableUsecase,
+         imageFetchUsecase: ImageFetchableUsecase,
          imageSaveUsecase: ImageSavableUsecase) {
         self.challengeID = challengeID
         self.challengeCreateUsecase = challengeCreateUsecase
         self.challengeUpdateUsecase = challengeUpdateUsecase
         self.challengeFetchUsecase = challengeFetchUsecase
+        self.imageFetchUsecase = imageFetchUsecase
         self.imageSaveUsecase = imageSaveUsecase
         self.title = ""
         self.category = .exercise
@@ -212,6 +219,14 @@ extension CreateViewModel {
 
     func saveImage(to directory: String, filename: String, data: Data?) -> String? {
         return imageSaveUsecase.saveImage(to: directory, filename: filename, data: data)
+    }
+
+    func imageData(from directory: String,
+                   filename: String,
+                   completion: ((Data?) -> Void)? = nil) {
+        imageFetchUsecase.fetchImageData(from: directory, filename: filename) { data in
+            completion?(data)
+        }
     }
 }
 

--- a/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
@@ -177,14 +177,14 @@ extension CreateViewModel {
         guard let category = category else { return }
         if buttonType.value == .create {
             challengeCreateUsecase.createChallenge(category: category,
-                                          title: title,
-                                          imageURL: imageURL,
-                                          thumbnailImageURL: thumbnailImageURL,
-                                          authExampleImageURL: authExampleImageURL,
-                                          authExampleThumbnailImageURL: authExampleThumbnailImageURL,
-                                          authMethod: authMethod,
-                                          week: week,
-                                          introduction: introduction)
+                                                   title: title,
+                                                   imageURL: imageURL,
+                                                   thumbnailImageURL: thumbnailImageURL,
+                                                   authExampleImageURL: authExampleImageURL,
+                                                   authExampleThumbnailImageURL: authExampleThumbnailImageURL,
+                                                   authMethod: authMethod,
+                                                   week: week,
+                                                   introduction: introduction)
         } else {
             updateChallenge()
         }
@@ -251,10 +251,10 @@ extension CreateViewModel {
 extension CreateViewModel {
     private func validate() {
         buttonState.value = !challengeCreateUsecase.isEmpty(title: title,
-                                                         imageURL: imageURL,
-                                                         introduction: introduction,
-                                                         authMethod: authMethod,
-                                                         authExampleImageURL: authExampleImageURL)
+                                                            imageURL: imageURL,
+                                                            introduction: introduction,
+                                                            authMethod: authMethod,
+                                                            authExampleImageURL: authExampleImageURL)
     }
 
     private func fetchChallenge() {
@@ -263,8 +263,8 @@ extension CreateViewModel {
             guard let self = self,
                   let challenge = existedChallenge else { return }
             self.challenge.value = challenge
-            self.updateAll(challenge: challenge)
             self.buttonType.value = .update
+            self.updateAll(challenge: challenge)
         }
     }
 }

--- a/Routinus/Routinus/Presentation/Create/Subviews/CreateAuthMethodView.swift
+++ b/Routinus/Routinus/Presentation/Create/Subviews/CreateAuthMethodView.swift
@@ -59,6 +59,10 @@ final class CreateAuthMethodView: UIView {
     func hideKeyboard() {
         textView.endEditing(true)
     }
+
+    func update(authMethod: String) {
+        textView.text = authMethod
+    }
 }
 
 extension CreateAuthMethodView {

--- a/Routinus/Routinus/Presentation/Create/Subviews/CreateCategoryView.swift
+++ b/Routinus/Routinus/Presentation/Create/Subviews/CreateCategoryView.swift
@@ -127,4 +127,8 @@ extension CreateCategoryView {
         alert.view.addConstraint(height)
         return alert
     }
+
+    func update(category: Challenge.Category) {
+        button.setTitle(category.title, for: .normal)
+    }
 }

--- a/Routinus/Routinus/Presentation/Create/Subviews/CreateIntroductionView.swift
+++ b/Routinus/Routinus/Presentation/Create/Subviews/CreateIntroductionView.swift
@@ -59,6 +59,10 @@ final class CreateIntroductionView: UIView {
     func hideKeyboard() {
         textView.endEditing(true)
     }
+
+    func update(introduction: String) {
+        textView.text = introduction
+    }
 }
 
 extension CreateIntroductionView {

--- a/Routinus/Routinus/Presentation/Create/Subviews/CreateTitleView.swift
+++ b/Routinus/Routinus/Presentation/Create/Subviews/CreateTitleView.swift
@@ -57,6 +57,10 @@ final class CreateTitleView: UIView {
     func hideKeyboard() {
         textField.endEditing(true)
     }
+
+    func update(title: String) {
+        textField.text = title
+    }
 }
 
 extension CreateTitleView {

--- a/Routinus/Routinus/Presentation/Create/Subviews/CreateWeekView.swift
+++ b/Routinus/Routinus/Presentation/Create/Subviews/CreateWeekView.swift
@@ -132,4 +132,9 @@ extension CreateWeekView {
     func updateEndDate(date: Date) {
         endDateLabel.text = date.toDateWithWeekdayString()
     }
+
+    func update(week: Int) {
+        weekTextField.text = "\(week)"
+    }
+
 }


### PR DESCRIPTION
## 작업 내용
- [x] 챌린지 update 로직 변경 
- [x] 챌린지 update 화면 구현
- [x] 챌린지 update시 상세화면에 업데이트 되도록 구현  

### 기타 사항
- 노션 작업도 있었고... 챌린지 수정하는 작업 시간이 너무 오래 걸려서... 챌린지 추가 시 Participation count + 1은 내일 하도록 하겠습니다... ㅠㅠ