### PR TITLE
[챌린지 관리 화면] 챌린지 추가 버튼 수정

### DIFF
--- a/Routinus/Routinus.xcodeproj/project.pbxproj
+++ b/Routinus/Routinus.xcodeproj/project.pbxproj
@@ -355,6 +355,14 @@
 			path = Cells;
 			sourceTree = "<group>";
 		};
+		0D18D072274B5D1800AD11F8 /* Subviews */ = {
+			isa = PBXGroup;
+			children = (
+				0D18D06E27492F2800AD11F8 /* AddChallengeView.swift */,
+			);
+			path = Subviews;
+			sourceTree = "<group>";
+		};
 		0DBBAA3827341C3600B32EB5 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
@@ -378,7 +386,6 @@
 			isa = PBXGroup;
 			children = (
 				E937044127434D4700D82B1D /* AuthMethodView.swift */,
-				0D18D06E27492F2800AD11F8 /* AddChallengeView.swift */,
 			);
 			path = Subviews;
 			sourceTree = "<group>";
@@ -759,6 +766,7 @@
 			children = (
 				E9797CAC2731074B00A14A0F /* ManageViewController.swift */,
 				0DE0339B274355760026F502 /* ManageViewModel.swift */,
+				0D18D072274B5D1800AD11F8 /* Subviews */,
 				0D18D06B2749166000AD11F8 /* Cells */,
 				446A0734274622F4009F8D98 /* Layouts */,
 			);

--- a/Routinus/Routinus.xcodeproj/project.pbxproj
+++ b/Routinus/Routinus.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		0D053E4E2746490A0042DAF2 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0D053E502746490A0042DAF2 /* Localizable.strings */; };
 		0D053E59274654390042DAF2 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D053E58274654390042DAF2 /* String+Extensions.swift */; };
 		0D18D06D2749167700AD11F8 /* ManageCollectionViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D18D06C2749167700AD11F8 /* ManageCollectionViewHeader.swift */; };
-		0D18D06F27492F2900AD11F8 /* AddChallengeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D18D06E27492F2800AD11F8 /* AddChallengeView.swift */; };
+		0D18D06F27492F2900AD11F8 /* ManageAddChallengeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D18D06E27492F2800AD11F8 /* ManageAddChallengeView.swift */; };
 		0D18D0712749CA4400AD11F8 /* ManageAddCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D18D0702749CA4400AD11F8 /* ManageAddCollectionViewCell.swift */; };
 		0DBBAA3727341C1600B32EB5 /* ChallengeCollectionViewLayouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBBAA3627341C1600B32EB5 /* ChallengeCollectionViewLayouts.swift */; };
 		0DBBAA3C27341C3600B32EB5 /* ChallengeRecommendCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBBAA3927341C3600B32EB5 /* ChallengeRecommendCollectionViewCell.swift */; };
@@ -181,7 +181,7 @@
 		0D053E512746491E0042DAF2 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		0D053E58274654390042DAF2 /* String+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		0D18D06C2749167700AD11F8 /* ManageCollectionViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageCollectionViewHeader.swift; sourceTree = "<group>"; };
-		0D18D06E27492F2800AD11F8 /* AddChallengeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChallengeView.swift; sourceTree = "<group>"; };
+		0D18D06E27492F2800AD11F8 /* ManageAddChallengeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageAddChallengeView.swift; sourceTree = "<group>"; };
 		0D18D0702749CA4400AD11F8 /* ManageAddCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageAddCollectionViewCell.swift; sourceTree = "<group>"; };
 		0DBBAA3627341C1600B32EB5 /* ChallengeCollectionViewLayouts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeCollectionViewLayouts.swift; sourceTree = "<group>"; };
 		0DBBAA3927341C3600B32EB5 /* ChallengeRecommendCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChallengeRecommendCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -358,7 +358,7 @@
 		0D18D072274B5D1800AD11F8 /* Subviews */ = {
 			isa = PBXGroup;
 			children = (
-				0D18D06E27492F2800AD11F8 /* AddChallengeView.swift */,
+				0D18D06E27492F2800AD11F8 /* ManageAddChallengeView.swift */,
 			);
 			path = Subviews;
 			sourceTree = "<group>";
@@ -1153,7 +1153,7 @@
 				0DC38F51273B684300331C25 /* SearchViewModel.swift in Sources */,
 				441CEDD627379939006C261F /* CalendarView.swift in Sources */,
 				0DFF32BD274548D8004FA9BD /* UIView+Extensions.swift in Sources */,
-				0D18D06F27492F2900AD11F8 /* AddChallengeView.swift in Sources */,
+				0D18D06F27492F2900AD11F8 /* ManageAddChallengeView.swift in Sources */,
 				E9E9D1EB273C1A4200F9CCBB /* SearchBarContainerView.swift in Sources */,
 				14B1810E27454DBF0061F2AE /* ParticipationRepository.swift in Sources */,
 				E901EFDC2744CAF900B14847 /* TodayRoutineRepository.swift in Sources */,

--- a/Routinus/Routinus/Presentation/Manage/Cells/ManageAddCollectionViewCell.swift
+++ b/Routinus/Routinus/Presentation/Manage/Cells/ManageAddCollectionViewCell.swift
@@ -36,7 +36,7 @@ final class ManageAddCollectionViewCell: UICollectionViewCell {
     }
 }
 
-extension  ManageAddCollectionViewCell {
+extension ManageAddCollectionViewCell {
     private func configureView() {
         let smallWidth = UIScreen.main.bounds.width <= 350
         let offset = smallWidth ? 28.0 : 32.0

--- a/Routinus/Routinus/Presentation/Manage/Cells/ManageAddCollectionViewCell.swift
+++ b/Routinus/Routinus/Presentation/Manage/Cells/ManageAddCollectionViewCell.swift
@@ -18,7 +18,7 @@ final class ManageAddCollectionViewCell: UICollectionViewCell {
         return label
     }()
 
-    private lazy var addChallengeView = AddChallengeView()
+    private lazy var addChallengeView = ManageAddChallengeView()
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Routinus/Routinus/Presentation/Manage/Cells/ManageAddCollectionViewCell.swift
+++ b/Routinus/Routinus/Presentation/Manage/Cells/ManageAddCollectionViewCell.swift
@@ -20,6 +20,12 @@ final class ManageAddCollectionViewCell: UICollectionViewCell {
 
     private lazy var addChallengeView = ManageAddChallengeView()
 
+    weak var delegate: AddChallengeDelegate? {
+        didSet {
+            addChallengeView.delegate = delegate
+        }
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureView()
@@ -45,9 +51,5 @@ extension  ManageAddCollectionViewCell {
         addSubview(addChallengeView)
         addChallengeView.anchor(horizontal: self,
                                 top: titleLabel.bottomAnchor, paddingTop: 10)
-    }
-
-    func addDelegate(_ delegate: AddChallengeDelegate) {
-        addChallengeView.delegate = delegate
     }
 }

--- a/Routinus/Routinus/Presentation/Manage/Cells/ManageAddCollectionViewCell.swift
+++ b/Routinus/Routinus/Presentation/Manage/Cells/ManageAddCollectionViewCell.swift
@@ -35,7 +35,7 @@ extension  ManageAddCollectionViewCell {
         let smallWidth = UIScreen.main.bounds.width <= 350
         let offset = smallWidth ? 28.0 : 32.0
 
-        anchor(height: 250)
+        anchor(height: 250 + offset)
 
         addSubview(titleLabel)
         titleLabel.anchor(horizontal: self,
@@ -44,8 +44,7 @@ extension  ManageAddCollectionViewCell {
 
         addSubview(addChallengeView)
         addChallengeView.anchor(horizontal: self,
-                                top: titleLabel.bottomAnchor, paddingTop: 10,
-                                bottom: self.bottomAnchor)
+                                top: titleLabel.bottomAnchor, paddingTop: 10)
     }
 
     func addDelegate(_ delegate: AddChallengeDelegate) {

--- a/Routinus/Routinus/Presentation/Manage/Cells/ManageAddCollectionViewCell.swift
+++ b/Routinus/Routinus/Presentation/Manage/Cells/ManageAddCollectionViewCell.swift
@@ -11,31 +11,15 @@ final class ManageAddCollectionViewCell: UICollectionViewCell {
     static let identifier = "ManageAddCollectionViewCell"
     weak var delegate: AddChallengeDelegate?
 
-    private lazy var stackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.axis = .vertical
-        stackView.spacing = 20
-        return stackView
-    }()
-
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.text = "원하는 챌린지를\n직접 만들어보세요!"
-        label.numberOfLines = 2
-        label.textAlignment = .center
-        label.font = .boldSystemFont(ofSize: 18)
+        label.text = "my challenges".localized
+        label.font = UIFont.systemFont(ofSize: UIScreen.main.bounds.width <= 350 ? 30 : 34,
+                                       weight: .bold)
         return label
     }()
 
-    private lazy var addButton: UIButton = {
-        let button = UIButton()
-        button.setTitle("챌린지 개설하기", for: .normal)
-        button.setTitleColor(.systemBackground, for: .normal)
-        button.backgroundColor = UIColor(named: "MainColor")
-        button.layer.cornerRadius = 5
-        button.addTarget(self, action: #selector(didTappedAddButton), for: .touchUpInside)
-        return button
-    }()
+    private lazy var addChallengeView = AddChallengeView()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -49,15 +33,20 @@ final class ManageAddCollectionViewCell: UICollectionViewCell {
 
 extension  ManageAddCollectionViewCell {
     private func configureView() {
-        backgroundColor = UIColor(named: "MainColor")?.withAlphaComponent(0.5)
-        layer.cornerRadius = 10
-        anchor(height: 160)
+        let smallWidth = UIScreen.main.bounds.width <= 350
+        let offset = smallWidth ? 28.0 : 32.0
 
-        addSubview(stackView)
-        stackView.addArrangedSubview(titleLabel)
-        stackView.addArrangedSubview(addButton)
-        stackView.anchor(centerX: centerXAnchor,
-                         centerY: centerYAnchor)
+        anchor(height: 250)
+
+        addSubview(titleLabel)
+        titleLabel.anchor(horizontal: self,
+                          top: topAnchor, paddingTop: offset,
+                          height: 80)
+
+        addSubview(addChallengeView)
+        addChallengeView.anchor(horizontal: self,
+                                top: titleLabel.bottomAnchor, paddingTop: 10,
+                                bottom: self.bottomAnchor)
     }
 
     @objc func didTappedAddButton() {

--- a/Routinus/Routinus/Presentation/Manage/Cells/ManageAddCollectionViewCell.swift
+++ b/Routinus/Routinus/Presentation/Manage/Cells/ManageAddCollectionViewCell.swift
@@ -9,16 +9,58 @@ import UIKit
 
 final class ManageAddCollectionViewCell: UICollectionViewCell {
     static let identifier = "ManageAddCollectionViewCell"
+    weak var delegate: AddChallengeDelegate?
 
-    private lazy var addView = AddChallengeView()
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 20
+        return stackView
+    }()
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "원하는 챌린지를\n직접 만들어보세요!"
+        label.numberOfLines = 2
+        label.textAlignment = .center
+        label.font = .boldSystemFont(ofSize: 18)
+        return label
+    }()
+
+    private lazy var addButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("챌린지 개설하기", for: .normal)
+        button.setTitleColor(.systemBackground, for: .normal)
+        button.backgroundColor = UIColor(named: "MainColor")
+        button.layer.cornerRadius = 5
+        button.addTarget(self, action: #selector(didTappedAddButton), for: .touchUpInside)
+        return button
+    }()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        addSubview(addView)
-        addView.anchor(edges: self)
+        configureView()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+    }
+}
+
+extension  ManageAddCollectionViewCell {
+    private func configureView() {
+        backgroundColor = UIColor(named: "MainColor")?.withAlphaComponent(0.5)
+        layer.cornerRadius = 10
+        anchor(height: 160)
+
+        addSubview(stackView)
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(addButton)
+        stackView.anchor(centerX: centerXAnchor,
+                         centerY: centerYAnchor)
+    }
+
+    @objc func didTappedAddButton() {
+        delegate?.didTappedAddButton()
     }
 }

--- a/Routinus/Routinus/Presentation/Manage/Cells/ManageAddCollectionViewCell.swift
+++ b/Routinus/Routinus/Presentation/Manage/Cells/ManageAddCollectionViewCell.swift
@@ -9,7 +9,6 @@ import UIKit
 
 final class ManageAddCollectionViewCell: UICollectionViewCell {
     static let identifier = "ManageAddCollectionViewCell"
-    weak var delegate: AddChallengeDelegate?
 
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
@@ -49,7 +48,7 @@ extension  ManageAddCollectionViewCell {
                                 bottom: self.bottomAnchor)
     }
 
-    @objc func didTappedAddButton() {
-        delegate?.didTappedAddButton()
+    func addDelegate(_ delegate: AddChallengeDelegate) {
+        addChallengeView.delegate = delegate
     }
 }

--- a/Routinus/Routinus/Presentation/Manage/Layouts/ManageCollectionViewLayouts.swift
+++ b/Routinus/Routinus/Presentation/Manage/Layouts/ManageCollectionViewLayouts.swift
@@ -17,7 +17,7 @@ final class ManageCollectionViewLayouts {
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
-                                               heightDimension: .estimated(250))
+                                               heightDimension: .estimated(250 + (smallWidth ? 28 : 32)))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
                                                        subitem: item,
                                                        count: 1)

--- a/Routinus/Routinus/Presentation/Manage/Layouts/ManageCollectionViewLayouts.swift
+++ b/Routinus/Routinus/Presentation/Manage/Layouts/ManageCollectionViewLayouts.swift
@@ -10,21 +10,21 @@ import UIKit
 final class ManageCollectionViewLayouts {
     private var addLayout: NSCollectionLayoutSection {
         let smallWidth = UIScreen.main.bounds.width <= 350
-        let offset = smallWidth ? 15.0 : 25.0
+        let offset = smallWidth ? 15.0 : 20.0
 
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .fractionalHeight(1))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
-                                               heightDimension: .estimated(160))
+                                               heightDimension: .estimated(250))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
                                                        subitem: item,
                                                        count: 1)
 
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .none
-        section.contentInsets = .init(top: 10, leading: offset, bottom: 10, trailing: offset)
+        section.contentInsets = .init(top: 0, leading: offset, bottom: 10, trailing: offset)
         return section
     }
 

--- a/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
+++ b/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
@@ -16,14 +16,6 @@ final class ManageViewController: UIViewController {
     typealias DataSource = UICollectionViewDiffableDataSource<Section, Challenge>
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Challenge>
 
-    private lazy var addButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(image: UIImage(systemName: "plus"),
-                                     style: .plain, target: self,
-                                     action: #selector(didTouchAddButton))
-        button.tintColor = UIColor(named: "Black")
-        return button
-    }()
-
     private var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout())
         collectionView.backgroundColor = .systemBackground
@@ -71,7 +63,6 @@ extension ManageViewController {
         navigationController?.navigationBar.prefersLargeTitles = true
         navigationItem.largeTitleDisplayMode = .always
         navigationItem.title = "my challenges".localized
-        navigationItem.rightBarButtonItem = addButton
     }
 
     private func configureViewModel() {
@@ -141,8 +132,8 @@ extension ManageViewController {
     }
 }
 
-extension ManageViewController {
-    @objc func didTouchAddButton() {
+extension ManageViewController: AddChallengeDelegate {
+    func didTappedAddButton() {
         viewModel?.didTappedAddButton()
     }
 
@@ -157,6 +148,7 @@ extension ManageViewController {
             if indexPath.section == 0 {
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ManageAddCollectionViewCell.identifier,
                                                               for: indexPath) as? ManageAddCollectionViewCell
+                cell?.delegate = self
                 return cell
             } else {
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ChallengeCollectionViewCell.identifier,

--- a/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
+++ b/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
@@ -12,9 +12,13 @@ final class ManageViewController: UIViewController {
     enum Section: CaseIterable {
         case add, participating, created, ended
     }
+    enum Item: Hashable {
+        case title
+        case challenge(Challenge)
+    }
 
-    typealias DataSource = UICollectionViewDiffableDataSource<Section, Challenge>
-    typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Challenge>
+    typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
+    typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
 
     private var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout())
@@ -49,6 +53,7 @@ final class ManageViewController: UIViewController {
         configureViews()
         configureCollectionView()
         configureViewModel()
+        configureTitle()
         didLoadedManageView()
     }
 
@@ -74,9 +79,10 @@ extension ManageViewController {
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] challengeItem in
                 guard let self = self else { return }
+                let contents = challengeItem.map { Item.challenge($0) }
                 var snapshot = self.dataSource.snapshot(for: .participating)
                 snapshot.deleteAll()
-                snapshot.append(challengeItem)
+                snapshot.append(contents)
                 self.dataSource.apply(snapshot, to: .participating)
             })
             .store(in: &cancellables)
@@ -85,9 +91,10 @@ extension ManageViewController {
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] challengeItem in
                 guard let self = self else { return }
+                let contents = challengeItem.map { Item.challenge($0) }
                 var snapshot = self.dataSource.snapshot(for: .created)
                 snapshot.deleteAll()
-                snapshot.append(challengeItem)
+                snapshot.append(contents)
                 self.dataSource.apply(snapshot, to: .created)
             })
             .store(in: &cancellables)
@@ -96,9 +103,10 @@ extension ManageViewController {
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] challengeItem in
                 guard let self = self else { return }
+                let contents = challengeItem.map { Item.challenge($0) }
                 var snapshot = self.dataSource.snapshot(for: .ended)
                 snapshot.deleteAll()
-                snapshot.append(challengeItem)
+                snapshot.append(contents)
                 self.dataSource.apply(snapshot, to: .ended)
             })
             .store(in: &cancellables)
@@ -107,25 +115,8 @@ extension ManageViewController {
     private func configureCollectionView() {
         collectionView.delegate = self
         collectionView.dataSource = dataSource
-        dataSource = configureDataSource()
-        configureHeader(of: dataSource)
 
-        var snapshot = self.dataSource.snapshot(for: .add)
-        snapshot.append([Challenge(challengeID: "",
-                                        title: "",
-                                        introduction: "",
-                                        category: .exercise,
-                                        imageURL: "",
-                                        thumbnailImageURL: "",
-                                        authExampleImageURL: "",
-                                        authExampleThumbnailImageURL: "",
-                                        authMethod: "",
-                                        startDate: Date(),
-                                        endDate: Date(),
-                                        ownerID: "",
-                                        week: 0,
-                                        participantCount: 0)])
-        dataSource.apply(snapshot, to: .add)
+        configureHeader(of: dataSource)
     }
 
     static func createLayout() -> UICollectionViewCompositionalLayout {
@@ -149,16 +140,18 @@ extension ManageViewController: AddChallengeDelegate {
 extension ManageViewController {
     private func configureDataSource() -> DataSource {
         let dataSource = DataSource(collectionView: collectionView) { collectionView, indexPath, content in
-            if indexPath.section == 0 {
+            switch content {
+            case .title:
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ManageAddCollectionViewCell.identifier,
                                                               for: indexPath) as? ManageAddCollectionViewCell
                 cell?.addDelegate(self)
                 return cell
-            } else {
+
+            case .challenge(let challenge):
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ChallengeCollectionViewCell.identifier,
                                                               for: indexPath) as? ChallengeCollectionViewCell
-                cell?.setTitle(content.title)
-                self.viewModel?.imageData(from: content.challengeID,
+                cell?.setTitle(challenge.title)
+                self.viewModel?.imageData(from: challenge.challengeID,
                                           filename: "thumbnail_image") { data in
                     guard let data = data,
                           let image = UIImage(data: data) else { return }
@@ -170,6 +163,10 @@ extension ManageViewController {
                 return cell
             }
         }
+
+        var snapshot = Snapshot()
+        snapshot.appendSections(Section.allCases)
+        dataSource.apply(snapshot, animatingDifferences: true)
         return dataSource
     }
 
@@ -206,6 +203,12 @@ extension ManageViewController {
             return view
         }
     }
+
+    private func configureTitle() {
+        var snapshot = self.dataSource.snapshot(for: .add)
+        snapshot.append([Item.title])
+        dataSource.apply(snapshot, to: .add)
+    }
 }
 
 extension ManageViewController: UICollectionViewDelegate {
@@ -225,7 +228,9 @@ extension ManageViewController: UIGestureRecognizerDelegate {
         case .participating:
             var snapshot = dataSource.snapshot(for: .participating)
             if headerView.isExpanded == true {
-                snapshot.append(viewModel?.participatingChallenges.value ?? [])
+                guard let challenges = viewModel?.participatingChallenges.value else { return }
+                let contents = challenges.map { Item.challenge($0) }
+                snapshot.append(contents)
             } else {
                 snapshot.deleteAll()
             }
@@ -233,7 +238,9 @@ extension ManageViewController: UIGestureRecognizerDelegate {
         case .created:
             var snapshot = dataSource.snapshot(for: .created)
             if headerView.isExpanded == true {
-                snapshot.append(viewModel?.createdChallenges.value ?? [])
+                guard let challenges = viewModel?.createdChallenges.value else { return }
+                let contents = challenges.map { Item.challenge($0) }
+                snapshot.append(contents)
             } else {
                 snapshot.deleteAll()
             }
@@ -241,7 +248,9 @@ extension ManageViewController: UIGestureRecognizerDelegate {
         case .ended:
             var snapshot = dataSource.snapshot(for: .ended)
             if headerView.isExpanded == true {
-                snapshot.append(viewModel?.endedChallenges.value ?? [])
+                guard let challenges = viewModel?.endedChallenges.value else { return }
+                let contents = challenges.map { Item.challenge($0) }
+                snapshot.append(contents)
             } else {
                 snapshot.deleteAll()
             }

--- a/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
+++ b/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
@@ -12,6 +12,7 @@ final class ManageViewController: UIViewController {
     enum Section: CaseIterable {
         case add, participating, created, ended
     }
+
     enum Item: Hashable {
         case title
         case challenge(Challenge)
@@ -144,7 +145,7 @@ extension ManageViewController {
             case .title:
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ManageAddCollectionViewCell.identifier,
                                                               for: indexPath) as? ManageAddCollectionViewCell
-                cell?.addDelegate(self)
+                cell?.delegate = self
                 return cell
 
             case .challenge(let challenge):

--- a/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
+++ b/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
@@ -52,17 +52,22 @@ final class ManageViewController: UIViewController {
         configureViewModel()
         didLoadedManageView()
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        self.navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        self.navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
 }
 
 extension ManageViewController {
     private func configureViews() {
         view.backgroundColor = .systemBackground
+
         view.addSubview(collectionView)
-        collectionView.anchor(horizontal: collectionView.superview,
-                              vertical: collectionView.superview)
-        navigationController?.navigationBar.prefersLargeTitles = true
-        navigationItem.largeTitleDisplayMode = .always
-        navigationItem.title = "my challenges".localized
+        collectionView.anchor(edges: view.safeAreaLayoutGuide)
     }
 
     private func configureViewModel() {

--- a/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
+++ b/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
@@ -32,7 +32,6 @@ final class ManageViewController: UIViewController {
         return collectionView
     }()
     private lazy var dataSource = configureDataSource()
-    private lazy var snapshot = Snapshot()
     private var viewModel: ManageViewModelIO?
     private var cancellables = Set<AnyCancellable>()
 
@@ -153,7 +152,7 @@ extension ManageViewController {
             if indexPath.section == 0 {
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ManageAddCollectionViewCell.identifier,
                                                               for: indexPath) as? ManageAddCollectionViewCell
-                cell?.delegate = self
+                cell?.addDelegate(self)
                 return cell
             } else {
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ChallengeCollectionViewCell.identifier,

--- a/Routinus/Routinus/Presentation/Manage/Subviews/AddChallengeView.swift
+++ b/Routinus/Routinus/Presentation/Manage/Subviews/AddChallengeView.swift
@@ -7,7 +7,13 @@
 
 import UIKit
 
+protocol AddChallengeDelegate: AnyObject {
+    func didTappedAddButton()
+}
+
 final class AddChallengeView: UIView {
+    weak var delegate: AddChallengeDelegate?
+
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
@@ -30,6 +36,7 @@ final class AddChallengeView: UIView {
         button.setTitleColor(.systemBackground, for: .normal)
         button.backgroundColor = UIColor(named: "MainColor")
         button.layer.cornerRadius = 5
+        button.addTarget(self, action: #selector(didTappedAddButton), for: .touchUpInside)
         return button
     }()
 
@@ -59,5 +66,9 @@ extension AddChallengeView {
         stackView.addArrangedSubview(addButton)
         stackView.anchor(centerX: centerXAnchor,
                          centerY: centerYAnchor)
+    }
+    
+    @objc func didTappedAddButton() {
+        delegate?.didTappedAddButton()
     }
 }

--- a/Routinus/Routinus/Presentation/Manage/Subviews/AddChallengeView.swift
+++ b/Routinus/Routinus/Presentation/Manage/Subviews/AddChallengeView.swift
@@ -67,7 +67,7 @@ extension AddChallengeView {
         stackView.anchor(centerX: centerXAnchor,
                          centerY: centerYAnchor)
     }
-    
+
     @objc func didTappedAddButton() {
         delegate?.didTappedAddButton()
     }

--- a/Routinus/Routinus/Presentation/Manage/Subviews/ManageAddChallengeView.swift
+++ b/Routinus/Routinus/Presentation/Manage/Subviews/ManageAddChallengeView.swift
@@ -11,7 +11,7 @@ protocol AddChallengeDelegate: AnyObject {
     func didTappedAddButton()
 }
 
-final class AddChallengeView: UIView {
+final class ManageAddChallengeView: UIView {
     weak var delegate: AddChallengeDelegate?
 
     private lazy var stackView: UIStackView = {
@@ -55,7 +55,7 @@ final class AddChallengeView: UIView {
     }
 }
 
-extension AddChallengeView {
+extension ManageAddChallengeView {
     private func configureView() {
         backgroundColor = UIColor(named: "MainColor")?.withAlphaComponent(0.5)
         layer.cornerRadius = 10


### PR DESCRIPTION
## 관련 issue
close #258 

## 작업 내용
- [x] addChallengeView Common에서 Manage-Subviews로 이동
- [x] addChallengeView의 챌린지 개설하기 버튼 연결 및 기존 + 버튼 제거
- [x] DiffableDataSource Item Hashable로 변경

## 기타사항
addChallengeView가 챌린지 추가 하라고 알려주는 뷰인데 마땅한 이름을 못찾았습니다..
천하제일 네이밍대회