### PR TITLE
[홈 화면] 캘린더 날짜 색상 이슈 수정

### DIFF
--- a/Routinus/Routinus/Presentation/Home/Cells/DateCollelctionViewCell.swift
+++ b/Routinus/Routinus/Presentation/Home/Cells/DateCollelctionViewCell.swift
@@ -96,17 +96,6 @@ extension DateCollectionViewCell {
         self.day = day
     }
 
-    func applyDayColor(_ day: Int) {
-        switch day {
-        case 0:
-            self.numberLabel.textColor = UIColor(named: "SundayColor")
-        case 6:
-            self.numberLabel.textColor = UIColor(named: "SaturdayColor")
-        default:
-            self.numberLabel.textColor = UIColor(named: "DayColor")
-        }
-    }
-
     private func configureViews() {
         contentView.addSubview(achievementCharacterView)
         contentView.addSubview(numberLabel)
@@ -117,14 +106,9 @@ private extension DateCollectionViewCell {
     func updateSelectionStatus() {
         guard let day = day else { return }
 
-        if day.isSelected {
-            applySelectedStyle()
-        } else {
-            applyDefaultStyle(
-                isWithinDisplayedMonth: day.isWithinDisplayedMonth,
-                weekday: Calendar.current.component(.weekday, from: day.date)
-            )
-        }
+        applyDefaultStyle(isWithinDisplayedMonth: day.isWithinDisplayedMonth,
+                         weekday: Calendar.current.component(.weekday, from: day.date))
+        day.isSelected ? applySelectedStyle() :  nil
     }
 
     var isSmallScreenSize: Bool {
@@ -137,15 +121,15 @@ private extension DateCollectionViewCell {
 
     func applySelectedStyle() {
         accessibilityTraits.insert(.selected)
-        accessibilityHint = nil
 
-        numberLabel.textColor = isSmallScreenSize ? UIColor(named: "MainColor") : UIColor(named: "DayColor")
+        if isSmallScreenSize {
+            numberLabel.textColor = UIColor(named: "MainColor")
+        }
         achievementCharacterView.isHidden = isSmallScreenSize
     }
 
     func applyDefaultStyle(isWithinDisplayedMonth: Bool, weekday: Int) {
         accessibilityTraits.remove(.selected)
-        accessibilityHint = "Tap to select"
         let color: UIColor?
         switch weekday {
         case 1:

--- a/Routinus/Routinus/Presentation/Home/Cells/DateCollelctionViewCell.swift
+++ b/Routinus/Routinus/Presentation/Home/Cells/DateCollelctionViewCell.swift
@@ -107,29 +107,13 @@ private extension DateCollectionViewCell {
         guard let day = day else { return }
 
         applyDefaultStyle(isWithinDisplayedMonth: day.isWithinDisplayedMonth,
-                         weekday: Calendar.current.component(.weekday, from: day.date))
-        day.isSelected ? applySelectedStyle() :  nil
-    }
-
-    var isSmallScreenSize: Bool {
-        let isCompact = traitCollection.horizontalSizeClass == .compact
-        let smallWidth = UIScreen.main.bounds.width <= 350
-        let widthGreaterThanHeight = UIScreen.main.bounds.width > UIScreen.main.bounds.height
-
-        return isCompact && (smallWidth || widthGreaterThanHeight)
-    }
-
-    func applySelectedStyle() {
-        accessibilityTraits.insert(.selected)
-
-        if isSmallScreenSize {
-            numberLabel.textColor = UIColor(named: "MainColor")
+                          weekday: Calendar.current.component(.weekday, from: day.date))
+        if day.isSelected {
+            achievementCharacterView.isHidden = false
         }
-        achievementCharacterView.isHidden = isSmallScreenSize
     }
 
     func applyDefaultStyle(isWithinDisplayedMonth: Bool, weekday: Int) {
-        accessibilityTraits.remove(.selected)
         let color: UIColor?
         switch weekday {
         case 1:

--- a/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
@@ -169,13 +169,13 @@ extension HomeViewModel {
     private func generateDay(offsetBy dayOffset: Int, for baseDate: Date, isWithinDisplayedMonth: Bool) -> Day {
         let date = calendar.date(byAdding: .day, value: dayOffset, to: baseDate) ?? baseDate
         let achievement = achievements.filter { "\($0.yearMonth)\($0.day)" == date.toDateString() }
-        let achieveRate = Double(achievement.first?.achievementCount ?? 0) / Double(achievement.first?.totalCount ?? 0)
+        let achievementRate = Double(achievement.first?.achievementCount ?? 0) / Double(achievement.first?.totalCount ?? 0)
         return Day(
             date: date,
             number: "\(date.day)",
             isSelected: selectedDates.contains(date),
             achievementRate: (achievement.count > 0
-                              ? achieveRate
+                              ? achievementRate
                               : 0),
             isWithinDisplayedMonth: isWithinDisplayedMonth
         )


### PR DESCRIPTION
## 관련 issue

close #245 

## 작업 내용
![image](https://user-images.githubusercontent.com/37893327/142865853-caa95461-cd49-4132-8435-75b0294a15ca.png)
- [x] 안쓰는 함수 삭제 (ㅠㅠ 죄송함다)
- [x] 주말 날짜 색상 회색으로 변하던 사항 수정 (스티커 붙일 때 날짜를 회색으로 바꾸고 있었습니다...)
- [x] 작은 화면일때도 스티커 보이도록 수정 (글씨 색보다 스티커가 더 알아보기 좋은 것 같음)