### PR TITLE
[챌린지 추가 화면] 챌린지 이미지를 변경할 때 이미지가 없어지는 문제 해결 

### DIFF
--- a/Routinus/Routinus.xcodeproj/project.pbxproj
+++ b/Routinus/Routinus.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		1497CF442738FFA600296F9E /* RoutinusRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1497CF432738FFA600296F9E /* RoutinusRepository.swift */; };
 		1497CF4C2739078700296F9E /* UserNameFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1497CF4B2739078700296F9E /* UserNameFactory.swift */; };
 		1497CF572739215C00296F9E /* UserCreateUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1497CF562739215C00296F9E /* UserCreateUsecase.swift */; };
+		149B8D9C274C6D410065E64D /* ImageUpdateUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B8D9B274C6D410065E64D /* ImageUpdateUsecase.swift */; };
 		14AFD0FA2746211F00011CC1 /* ChallengeAuthFetchUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AFD0F92746211F00011CC1 /* ChallengeAuthFetchUsecase.swift */; };
 		14B1810E27454DBF0061F2AE /* ParticipationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B1810D27454DBF0061F2AE /* ParticipationRepository.swift */; };
 		14B181122745511A0061F2AE /* Participation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B181112745511A0061F2AE /* Participation.swift */; };
@@ -206,6 +207,7 @@
 		1497CF432738FFA600296F9E /* RoutinusRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutinusRepository.swift; sourceTree = "<group>"; };
 		1497CF4B2739078700296F9E /* UserNameFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNameFactory.swift; sourceTree = "<group>"; };
 		1497CF562739215C00296F9E /* UserCreateUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCreateUsecase.swift; sourceTree = "<group>"; };
+		149B8D9B274C6D410065E64D /* ImageUpdateUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUpdateUsecase.swift; sourceTree = "<group>"; };
 		14AFD0F92746211F00011CC1 /* ChallengeAuthFetchUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeAuthFetchUsecase.swift; sourceTree = "<group>"; };
 		14B1810D27454DBF0061F2AE /* ParticipationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipationRepository.swift; sourceTree = "<group>"; };
 		14B181112745511A0061F2AE /* Participation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Participation.swift; sourceTree = "<group>"; };
@@ -659,6 +661,7 @@
 				E9A7943E274618AB00731DEB /* AchievementUpdateUsecase.swift */,
 				E901EFD52744BDBD00B14847 /* ImageFetchUsecase.swift */,
 				E901EFE32744D41600B14847 /* ImageSaveUsecase.swift */,
+				149B8D9B274C6D410065E64D /* ImageUpdateUsecase.swift */,
 				E901EFE927453F2000B14847 /* ChallengeAuthCreateUsecase.swift */,
 				14AFD0F92746211F00011CC1 /* ChallengeAuthFetchUsecase.swift */,
 				14B18115274555CE0061F2AE /* ParticipationFetchUsecase.swift */,
@@ -1192,6 +1195,7 @@
 				E937044427434D6300D82B1D /* PreviewView.swift in Sources */,
 				E9797CBB27310E1000A14A0F /* ChallengeCoordinator.swift in Sources */,
 				0DBBAA3E27341C3600B32EB5 /* ChallengeCollectionViewHeader.swift in Sources */,
+				149B8D9C274C6D410065E64D /* ImageUpdateUsecase.swift in Sources */,
 				E9797CB92731094900A14A0F /* AuthViewController.swift in Sources */,
 				E9797CB1273107A200A14A0F /* DetailViewController.swift in Sources */,
 				1497CF4C2739078700296F9E /* UserNameFactory.swift in Sources */,

--- a/Routinus/Routinus/Application/Coordinator/CreateCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/CreateCoordinator.swift
@@ -31,13 +31,15 @@ final class CreateCoordinator: RoutinusCoordinator {
         let challengeFetchUsecase = ChallengeFetchUsecase(repository: repository)
         let imageFetchUsecase = ImageFetchUsecase(repository: repository)
         let imageSaveUsecase = ImageSaveUsecase(repository: repository)
+        let imageUpdateUsecase = ImageUpdateUsecase(repository: repository)
 
         let createViewModel = CreateViewModel(challengeID: challengeID,
                                               challengeCreateUsecase: challengeCreateUsecase,
                                               challengeUpdateUsecase: challengeUpdateUsecase,
                                               challengeFetchUsecase: challengeFetchUsecase,
                                               imageFetchUsecase: imageFetchUsecase,
-                                              imageSaveUsecase: imageSaveUsecase)
+                                              imageSaveUsecase: imageSaveUsecase,
+                                              imageUpdateUsecase: imageUpdateUsecase)
         let createViewController = CreateViewController(with: createViewModel)
         createViewController.hidesBottomBarWhenPushed = true
         self.navigationController.pushViewController(createViewController, animated: true)

--- a/Routinus/Routinus/Data/ChallengeRepository.swift
+++ b/Routinus/Routinus/Data/ChallengeRepository.swift
@@ -30,11 +30,9 @@ protocol ChallengeRepository {
               thumbnailImageURL: String,
               authExampleImageURL: String,
               authExampleThumbnailImageURL: String)
-    func update(challenge: Challenge,
-                imageURL: String,
-                thumbnailImageURL: String,
-                authExampleImageURL: String,
-                authExampleThumbnailImageURL: String)
+    func update(challenge: Challenge)
+    func updateImage(challengeID: String, imageURL: String, thumbnailImageURL: String)
+    func updateImage(challengeID: String, authExampleImageURL: String, authExampleThumbnailImageURL: String)
 }
 
 extension RoutinusRepository: ChallengeRepository {
@@ -137,11 +135,7 @@ extension RoutinusRepository: ChallengeRepository {
         }
     }
 
-    func update(challenge: Challenge,
-                imageURL: String,
-                thumbnailImageURL: String,
-                authExampleImageURL: String,
-                authExampleThumbnailImageURL: String) {
+    func update(challenge: Challenge) {
         guard let startDate = challenge.startDate?.toDateString(),
               let endDate = challenge.endDate?.toDateString() else { return }
         let challengeDTO = ChallengeDTO(id: challenge.challengeID,
@@ -154,13 +148,31 @@ extension RoutinusRepository: ChallengeRepository {
                                         endDate: endDate,
                                         participantCount: challenge.participantCount,
                                         ownerID: challenge.ownerID)
+        RoutinusNetwork.updateChallenge(challengeDTO: challengeDTO,
+                                        completion: nil)
+    }
 
-        RoutinusNetwork.patchChallenge(challengeDTO: challengeDTO,
-                                       imageURL: imageURL,
-                                       thumbnailImageURL: thumbnailImageURL,
-                                       authExampleImageURL: authExampleImageURL,
-                                       authExampleThumbnailImageURL: authExampleThumbnailImageURL) {
-            RoutinusStorage.removeCachedImages(from: challenge.challengeID)
-        }
+    func updateImage(challengeID: String, imageURL: String, thumbnailImageURL: String) {
+        RoutinusNetwork.uploadImage(id: challengeID,
+                                    filename: "image",
+                                    imageURL: imageURL,
+                                    completion: nil)
+        RoutinusNetwork.uploadImage(id: challengeID,
+                                    filename: "thumbnail_image",
+                                    imageURL: thumbnailImageURL,
+                                    completion: nil)
+        RoutinusStorage.removeCachedImages(from: challengeID)
+    }
+
+    func updateImage(challengeID: String, authExampleImageURL: String, authExampleThumbnailImageURL: String) {
+        RoutinusNetwork.uploadImage(id: challengeID,
+                                    filename: "auth",
+                                    imageURL: authExampleImageURL,
+                                    completion: nil)
+        RoutinusNetwork.uploadImage(id: challengeID,
+                                    filename: "thumbnail_auth",
+                                    imageURL: authExampleThumbnailImageURL,
+                                    completion: nil)
+        RoutinusStorage.removeCachedImages(from: challengeID)
     }
 }

--- a/Routinus/Routinus/Data/ChallengeRepository.swift
+++ b/Routinus/Routinus/Data/ChallengeRepository.swift
@@ -31,12 +31,6 @@ protocol ChallengeRepository {
               authExampleImageURL: String,
               authExampleThumbnailImageURL: String)
     func update(challenge: Challenge)
-    func updateImage(challengeID: String,
-                     imageURL: String,
-                     thumbnailImageURL: String)
-    func updateImage(challengeID: String,
-                     authExampleImageURL: String,
-                     authExampleThumbnailImageURL: String)
 }
 
 extension RoutinusRepository: ChallengeRepository {
@@ -154,33 +148,5 @@ extension RoutinusRepository: ChallengeRepository {
                                         ownerID: challenge.ownerID)
         RoutinusNetwork.updateChallenge(challengeDTO: challengeDTO,
                                         completion: nil)
-    }
-
-    func updateImage(challengeID: String,
-                     imageURL: String,
-                     thumbnailImageURL: String) {
-        RoutinusNetwork.uploadImage(id: challengeID,
-                                    filename: "image",
-                                    imageURL: imageURL,
-                                    completion: nil)
-        RoutinusNetwork.uploadImage(id: challengeID,
-                                    filename: "thumbnail_image",
-                                    imageURL: thumbnailImageURL,
-                                    completion: nil)
-        RoutinusStorage.removeCachedImages(from: challengeID)
-    }
-
-    func updateImage(challengeID: String,
-                     authExampleImageURL: String,
-                     authExampleThumbnailImageURL: String) {
-        RoutinusNetwork.uploadImage(id: challengeID,
-                                    filename: "auth",
-                                    imageURL: authExampleImageURL,
-                                    completion: nil)
-        RoutinusNetwork.uploadImage(id: challengeID,
-                                    filename: "thumbnail_auth",
-                                    imageURL: authExampleThumbnailImageURL,
-                                    completion: nil)
-        RoutinusStorage.removeCachedImages(from: challengeID)
     }
 }

--- a/Routinus/Routinus/Data/ChallengeRepository.swift
+++ b/Routinus/Routinus/Data/ChallengeRepository.swift
@@ -31,8 +31,12 @@ protocol ChallengeRepository {
               authExampleImageURL: String,
               authExampleThumbnailImageURL: String)
     func update(challenge: Challenge)
-    func updateImage(challengeID: String, imageURL: String, thumbnailImageURL: String)
-    func updateImage(challengeID: String, authExampleImageURL: String, authExampleThumbnailImageURL: String)
+    func updateImage(challengeID: String,
+                     imageURL: String,
+                     thumbnailImageURL: String)
+    func updateImage(challengeID: String,
+                     authExampleImageURL: String,
+                     authExampleThumbnailImageURL: String)
 }
 
 extension RoutinusRepository: ChallengeRepository {
@@ -152,7 +156,9 @@ extension RoutinusRepository: ChallengeRepository {
                                         completion: nil)
     }
 
-    func updateImage(challengeID: String, imageURL: String, thumbnailImageURL: String) {
+    func updateImage(challengeID: String,
+                     imageURL: String,
+                     thumbnailImageURL: String) {
         RoutinusNetwork.uploadImage(id: challengeID,
                                     filename: "image",
                                     imageURL: imageURL,
@@ -164,7 +170,9 @@ extension RoutinusRepository: ChallengeRepository {
         RoutinusStorage.removeCachedImages(from: challengeID)
     }
 
-    func updateImage(challengeID: String, authExampleImageURL: String, authExampleThumbnailImageURL: String) {
+    func updateImage(challengeID: String,
+                     authExampleImageURL: String,
+                     authExampleThumbnailImageURL: String) {
         RoutinusNetwork.uploadImage(id: challengeID,
                                     filename: "auth",
                                     imageURL: authExampleImageURL,

--- a/Routinus/Routinus/Data/ImageRepository.swift
+++ b/Routinus/Routinus/Data/ImageRepository.swift
@@ -17,6 +17,12 @@ protocol ImageRepository {
     func saveImage(to directory: String,
                    filename: String,
                    data: Data?) -> String?
+    func updateImage(challengeID: String,
+                     imageURL: String,
+                     thumbnailImageURL: String)
+    func updateImage(challengeID: String,
+                     authExampleImageURL: String,
+                     authExampleThumbnailImageURL: String)
 }
 
 extension RoutinusRepository: ImageRepository {
@@ -41,5 +47,33 @@ extension RoutinusRepository: ImageRepository {
         return RoutinusStorage.saveImage(to: directory,
                                          filename: filename,
                                          imageData: data)
+    }
+
+    func updateImage(challengeID: String,
+                     imageURL: String,
+                     thumbnailImageURL: String) {
+        RoutinusNetwork.uploadImage(id: challengeID,
+                                    filename: "image",
+                                    imageURL: imageURL,
+                                    completion: nil)
+        RoutinusNetwork.uploadImage(id: challengeID,
+                                    filename: "thumbnail_image",
+                                    imageURL: thumbnailImageURL,
+                                    completion: nil)
+        RoutinusStorage.removeCachedImages(from: challengeID)
+    }
+
+    func updateImage(challengeID: String,
+                     authExampleImageURL: String,
+                     authExampleThumbnailImageURL: String) {
+        RoutinusNetwork.uploadImage(id: challengeID,
+                                    filename: "auth",
+                                    imageURL: authExampleImageURL,
+                                    completion: nil)
+        RoutinusNetwork.uploadImage(id: challengeID,
+                                    filename: "thumbnail_auth",
+                                    imageURL: authExampleThumbnailImageURL,
+                                    completion: nil)
+        RoutinusStorage.removeCachedImages(from: challengeID)
     }
 }

--- a/Routinus/Routinus/Domain/Usecase/ChallengeUpdateUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/ChallengeUpdateUsecase.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 protocol ChallengeUpdatableUsecase {
-    func updateChallenge(challenge: Challenge)
+    func updateChallenge(challenge: Challenge,
+                         isChangedImage: Bool,
+                         isChangedAuthImage: Bool)
     func endDate(startDate: Date, week: Int) -> Date?
 }
 
@@ -26,11 +28,18 @@ struct ChallengeUpdateUsecase: ChallengeUpdatableUsecase {
         return endDate
     }
 
-    func updateChallenge(challenge: Challenge) {
-        repository.update(challenge: challenge,
-                          imageURL: challenge.imageURL,
-                          thumbnailImageURL: challenge.thumbnailImageURL,
-                          authExampleImageURL: challenge.authExampleImageURL,
-                          authExampleThumbnailImageURL: challenge.authExampleThumbnailImageURL)
+    func updateChallenge(challenge: Challenge, isChangedImage: Bool, isChangedAuthImage: Bool) {
+        repository.update(challenge: challenge)
+        if isChangedImage {
+            repository.updateImage(challengeID: challenge.challengeID,
+                                   imageURL: challenge.imageURL,
+                                   thumbnailImageURL: challenge.thumbnailImageURL)
+        }
+        if isChangedAuthImage {
+            repository.updateImage(challengeID: challenge.challengeID,
+                                   authExampleImageURL: challenge.authExampleImageURL,
+                                   authExampleThumbnailImageURL: challenge.authExampleThumbnailImageURL)
+        }
+
     }
 }

--- a/Routinus/Routinus/Domain/Usecase/ChallengeUpdateUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/ChallengeUpdateUsecase.swift
@@ -28,7 +28,9 @@ struct ChallengeUpdateUsecase: ChallengeUpdatableUsecase {
         return endDate
     }
 
-    func updateChallenge(challenge: Challenge, isChangedImage: Bool, isChangedAuthImage: Bool) {
+    func updateChallenge(challenge: Challenge,
+                         isChangedImage: Bool,
+                         isChangedAuthImage: Bool) {
         repository.update(challenge: challenge)
         if isChangedImage {
             repository.updateImage(challengeID: challenge.challengeID,

--- a/Routinus/Routinus/Domain/Usecase/ChallengeUpdateUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/ChallengeUpdateUsecase.swift
@@ -9,9 +9,7 @@ import Foundation
 
 protocol ChallengeUpdatableUsecase {
     func endDate(startDate: Date, week: Int) -> Date?
-    func updateChallenge(challenge: Challenge,
-                         isChangedImage: Bool,
-                         isChangedAuthImage: Bool)
+    func update(challenge: Challenge)
 }
 
 struct ChallengeUpdateUsecase: ChallengeUpdatableUsecase {
@@ -28,20 +26,7 @@ struct ChallengeUpdateUsecase: ChallengeUpdatableUsecase {
         return endDate
     }
 
-    func updateChallenge(challenge: Challenge,
-                         isChangedImage: Bool,
-                         isChangedAuthImage: Bool) {
+    func update(challenge: Challenge) {
         repository.update(challenge: challenge)
-        if isChangedImage {
-            repository.updateImage(challengeID: challenge.challengeID,
-                                   imageURL: challenge.imageURL,
-                                   thumbnailImageURL: challenge.thumbnailImageURL)
-        }
-        if isChangedAuthImage {
-            repository.updateImage(challengeID: challenge.challengeID,
-                                   authExampleImageURL: challenge.authExampleImageURL,
-                                   authExampleThumbnailImageURL: challenge.authExampleThumbnailImageURL)
-        }
-
     }
 }

--- a/Routinus/Routinus/Domain/Usecase/ChallengeUpdateUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/ChallengeUpdateUsecase.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 protocol ChallengeUpdatableUsecase {
+    func endDate(startDate: Date, week: Int) -> Date?
     func updateChallenge(challenge: Challenge,
                          isChangedImage: Bool,
                          isChangedAuthImage: Bool)
-    func endDate(startDate: Date, week: Int) -> Date?
 }
 
 struct ChallengeUpdateUsecase: ChallengeUpdatableUsecase {

--- a/Routinus/Routinus/Domain/Usecase/ImageUpdateUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/ImageUpdateUsecase.swift
@@ -1,0 +1,38 @@
+//
+//  ImageUpdateUsecase.swift
+//  Routinus
+//
+//  Created by 백지현 on 2021/11/23.
+//
+
+import Foundation
+
+protocol ImageUpdatableUsecase {
+    func updateImage(challenge: Challenge,
+                     isChangedImage: Bool,
+                     isChangedAuthImage: Bool)
+}
+
+struct ImageUpdateUsecase: ImageUpdatableUsecase {
+    var repository: ImageRepository
+
+    init(repository: ImageRepository) {
+        self.repository = repository
+    }
+
+    func updateImage(challenge: Challenge,
+                     isChangedImage: Bool,
+                     isChangedAuthImage: Bool) {
+        if isChangedImage {
+            repository.updateImage(challengeID: challenge.challengeID,
+                                   imageURL: challenge.imageURL,
+                                   thumbnailImageURL: challenge.thumbnailImageURL)
+        }
+        if isChangedAuthImage {
+            repository.updateImage(challengeID: challenge.challengeID,
+                                   authExampleImageURL: challenge.authExampleImageURL,
+                                   authExampleThumbnailImageURL: challenge.authExampleThumbnailImageURL)
+        }
+
+    }
+}

--- a/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
@@ -75,6 +75,7 @@ final class CreateViewModel: CreateViewModelIO {
     var challengeFetchUsecase: ChallengeFetchableUsecase
     var imageFetchUsecase: ImageFetchableUsecase
     var imageSaveUsecase: ImageSavableUsecase
+    var imageUpdateUsecase: ImageUpdatableUsecase
     var challengeID: String?
 
     private var title: String
@@ -95,13 +96,15 @@ final class CreateViewModel: CreateViewModelIO {
          challengeUpdateUsecase: ChallengeUpdatableUsecase,
          challengeFetchUsecase: ChallengeFetchableUsecase,
          imageFetchUsecase: ImageFetchableUsecase,
-         imageSaveUsecase: ImageSavableUsecase) {
+         imageSaveUsecase: ImageSavableUsecase,
+         imageUpdateUsecase: ImageUpdatableUsecase) {
         self.challengeID = challengeID
         self.challengeCreateUsecase = challengeCreateUsecase
         self.challengeUpdateUsecase = challengeUpdateUsecase
         self.challengeFetchUsecase = challengeFetchUsecase
         self.imageFetchUsecase = imageFetchUsecase
         self.imageSaveUsecase = imageSaveUsecase
+        self.imageUpdateUsecase = imageUpdateUsecase
         self.title = ""
         self.category = .exercise
         self.imageURL = ""
@@ -229,7 +232,6 @@ extension CreateViewModel {
               let endDate = challengeUpdateUsecase.endDate(startDate: startDate, week: week),
               let category = category else { return }
 
-
         let updateChallenge = Challenge(challengeID: challenge.challengeID,
                                         title: title,
                                         introduction: introduction,
@@ -245,9 +247,10 @@ extension CreateViewModel {
                                         week: week,
                                         participantCount: challenge.participantCount)
 
-        challengeUpdateUsecase.updateChallenge(challenge: updateChallenge,
-                                               isChangedImage: isChangedImage,
-                                               isChangedAuthImage: isChangedAuthImage)
+        challengeUpdateUsecase.update(challenge: updateChallenge)
+        imageUpdateUsecase.updateImage(challenge: updateChallenge,
+                                       isChangedImage: isChangedImage,
+                                       isChangedAuthImage: isChangedAuthImage)
     }
 
     func saveImage(to directory: String, filename: String, data: Data?) -> String? {

--- a/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
@@ -87,6 +87,9 @@ final class CreateViewModel: CreateViewModelIO {
     private var authExampleImageURL: String
     private var authExampleThumbnailImageURL: String
 
+    private var isChangedImage: Bool
+    private var isChangedAuthImage: Bool
+
     init(challengeID: String? = nil,
          challengeCreateUsecase: ChallengeCreatableUsecase,
          challengeUpdateUsecase: ChallengeUpdatableUsecase,
@@ -108,6 +111,8 @@ final class CreateViewModel: CreateViewModelIO {
         self.authMethod = ""
         self.authExampleImageURL = ""
         self.authExampleThumbnailImageURL = ""
+        self.isChangedImage = false
+        self.isChangedAuthImage = false
     }
 }
 
@@ -124,6 +129,7 @@ extension CreateViewModel {
 
     func update(imageURL: String?) {
         self.imageURL = imageURL ?? ""
+        self.isChangedImage = true
         self.validate()
     }
 
@@ -151,6 +157,7 @@ extension CreateViewModel {
 
     func update(authExampleImageURL: String?) {
         self.authExampleImageURL = authExampleImageURL ?? ""
+        self.isChangedAuthImage = true
         self.validate()
     }
 
@@ -161,13 +168,16 @@ extension CreateViewModel {
 
     func updateAll(challenge: Challenge) {
         guard let startDate = challenge.startDate else { return }
+
         self.category = challenge.category
         self.title = challenge.title
         self.imageURL = challenge.imageURL
+        self.thumbnailImageURL = challenge.thumbnailImageURL
         self.week = challenge.week
         self.introduction = challenge.introduction
         self.authMethod = challenge.authMethod
         self.authExampleImageURL = challenge.authExampleImageURL
+        self.authExampleThumbnailImageURL = challenge.authExampleThumbnailImageURL
         guard let endDate = challengeUpdateUsecase.endDate(startDate: startDate, week: week) else { return }
         expectedEndDate.value = endDate
         self.validate()
@@ -218,6 +228,8 @@ extension CreateViewModel {
               let startDate = challenge.startDate,
               let endDate = challengeUpdateUsecase.endDate(startDate: startDate, week: week),
               let category = category else { return }
+
+
         let updateChallenge = Challenge(challengeID: challenge.challengeID,
                                         title: title,
                                         introduction: introduction,
@@ -232,7 +244,10 @@ extension CreateViewModel {
                                         ownerID: challenge.ownerID,
                                         week: week,
                                         participantCount: challenge.participantCount)
-        challengeUpdateUsecase.updateChallenge(challenge: updateChallenge)
+
+        challengeUpdateUsecase.updateChallenge(challenge: updateChallenge,
+                                               isChangedImage: isChangedImage,
+                                               isChangedAuthImage: isChangedAuthImage)
     }
 
     func saveImage(to directory: String, filename: String, data: Data?) -> String? {
@@ -242,7 +257,8 @@ extension CreateViewModel {
     func imageData(from directory: String,
                    filename: String,
                    completion: ((Data?) -> Void)? = nil) {
-        imageFetchUsecase.fetchImageData(from: directory, filename: filename) { data in
+        imageFetchUsecase.fetchImageData(from: directory,
+                                         filename: filename) { data in
             completion?(data)
         }
     }

--- a/Routinus/RoutinusNetwork/RoutinusNetwork.swift
+++ b/Routinus/RoutinusNetwork/RoutinusNetwork.swift
@@ -519,43 +519,6 @@ public enum RoutinusNetwork {
         }.resume()
     }
 
-    public static func patchChallenge(challengeDTO: ChallengeDTO,
-                                      imageURL: String,
-                                      thumbnailImageURL: String,
-                                      authExampleImageURL: String,
-                                      authExampleThumbnailImageURL: String,
-                                      completion: (() -> Void)?) {
-        updateChallenge(challengeDTO: challengeDTO,
-                        completion: nil)
-
-        let patchQueue = DispatchQueue(label: "patchQueue")
-        let group = DispatchGroup()
-
-        patchQueue.async(group: group) {
-            let id = challengeDTO.document?.fields.id.stringValue ?? ""
-            uploadImage(id: id,
-                        filename: "image",
-                        imageURL: imageURL,
-                        completion: nil)
-            uploadImage(id: id,
-                        filename: "thumbnail_image",
-                        imageURL: thumbnailImageURL,
-                        completion: nil)
-            uploadImage(id: id,
-                        filename: "auth",
-                        imageURL: authExampleImageURL,
-                        completion: nil)
-            uploadImage(id: id,
-                        filename: "thumbnail_auth",
-                        imageURL: authExampleImageURL,
-                        completion: nil)
-        }
-
-        group.notify(queue: patchQueue) {
-            completion?()
-        }
-    }
-
     public static func updateContinuityDay(of id: String,
                                            completion: (() -> Void)?) {
         user(of: id) { dto in


### PR DESCRIPTION
## 관련 issue

Close #255

## 작업 내용
- [x] 이미지를 변경하지 않았을 때와 이미지를 하나만 변경 했을 경우 상세 화면에서 이미지가 사라지는 문제 해결
- [x] 이미지가 변경되지 않았을 때 네트워크 요청하지 않도록 리팩토링 

## 기타 사항
- `이미지를 변경하지 않았을 때와 이미지를 하나만 변경 했을 경우 상세 화면에서 이미지가 사라지는 문제 해결` 문제는 변수명 오타 때문이였습니다 ... ㅎ
- 기존 구조에서는 이미지가 변경되지 않아도 네트워크에서 이미지 URL이 변경되도록 요청했는데, 이미지가 변경되지 않았을 때는 네트워크 요청이 일어나지 않도록 구조를 개선하였습니다. 
