### PR TITLE
[홈화면] 초기 데이터 설정 로직 변경 및 오늘루틴셀 인증완료 표시

### DIFF
--- a/Routinus/Routinus/Application/AppDelegate.swift
+++ b/Routinus/Routinus/Application/AppDelegate.swift
@@ -16,11 +16,4 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-    
-    func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        let repository = RoutinusRepository()
-        let userCreateUsecase = UserCreateUsecase(repository: repository)
-        userCreateUsecase.createUserID()
-        return true
-    }
 }

--- a/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
@@ -29,10 +29,12 @@ final class HomeCoordinator: RoutinusCoordinator {
         let userFetchUsecase = UserFetchUsecase(repository: repository)
         let todayRoutineFetchUsecase = TodayRoutineFetchUsecase(repository: repository)
         let achievementFetchUsecase = AchievementFetchUsecase(repository: repository)
+        let challengeAuthFetchUsecase = ChallengeAuthFetchUsecase(repository: repository)
         let homeViewModel = HomeViewModel(userCreateUsecase: userCreateUsecase,
                                           userFetchUsecase: userFetchUsecase,
                                           todayRoutineFetchUsecase: todayRoutineFetchUsecase,
-                                          achievementFetchUsecase: achievementFetchUsecase)
+                                          achievementFetchUsecase: achievementFetchUsecase,
+                                          challengeAuthFetchUsecase: challengeAuthFetchUsecase)
         let homeViewController = HomeViewController(with: homeViewModel)
 
         homeViewModel.challengeAddButtonTap

--- a/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
@@ -27,11 +27,13 @@ final class HomeCoordinator: RoutinusCoordinator {
         let repository = RoutinusRepository()
         let userCreateUsecase = UserCreateUsecase(repository: repository)
         let userFetchUsecase = UserFetchUsecase(repository: repository)
+        let userUpdateUsecase = UserUpdateUsecase(repository: repository)
         let todayRoutineFetchUsecase = TodayRoutineFetchUsecase(repository: repository)
         let achievementFetchUsecase = AchievementFetchUsecase(repository: repository)
         let challengeAuthFetchUsecase = ChallengeAuthFetchUsecase(repository: repository)
         let homeViewModel = HomeViewModel(userCreateUsecase: userCreateUsecase,
                                           userFetchUsecase: userFetchUsecase,
+                                          userUpdateUsecase: userUpdateUsecase,
                                           todayRoutineFetchUsecase: todayRoutineFetchUsecase,
                                           achievementFetchUsecase: achievementFetchUsecase,
                                           challengeAuthFetchUsecase: challengeAuthFetchUsecase)

--- a/Routinus/Routinus/Data/UserRepository.swift
+++ b/Routinus/Routinus/Data/UserRepository.swift
@@ -12,7 +12,8 @@ import RoutinusNetwork
 protocol UserRepository {
     func isEmptyUserID() -> Bool
     func save(id: String,
-              name: String)
+              name: String,
+              completion: ((UserDTO) -> Void)?)
     func fetchUser(by id: String,
                    completion: ((User) -> Void)?)
     func updateContinuityDay(by id: String)
@@ -28,12 +29,15 @@ extension RoutinusRepository: UserRepository {
     }
 
     func save(id: String,
-              name: String) {
+              name: String,
+              completion: ((UserDTO) -> Void)?) {
         UserDefaults.standard.set(id,
                                   forKey: RoutinusRepository.userIDKey)
         RoutinusNetwork.insertUser(id: id,
-                                   name: name,
-                                   completion: nil)
+                                   name: name) { dto in
+            guard let dto = dto else { return }
+            completion?(dto)
+        }
     }
 
     func fetchUser(by id: String,

--- a/Routinus/Routinus/Data/UserRepository.swift
+++ b/Routinus/Routinus/Data/UserRepository.swift
@@ -16,6 +16,8 @@ protocol UserRepository {
               completion: ((UserDTO) -> Void)?)
     func fetchUser(by id: String,
                    completion: ((User) -> Void)?)
+    func updateContinuityDay(by id: String,
+                             completion: ((UserDTO) -> Void)?)
     func updateContinuityDayByAuth(by id: String)
     func fetchThemeStyle() -> Int
     func updateUsername(of id: String,
@@ -44,6 +46,13 @@ extension RoutinusRepository: UserRepository {
                    completion: ((User) -> Void)?) {
         RoutinusNetwork.user(of: id) { dto in
             completion?(User(userDTO: dto))
+        }
+    }
+
+    func updateContinuityDay(by id: String,
+                             completion: ((UserDTO) -> Void)?) {
+        RoutinusNetwork.updateContinuityDay(of: id) { dto in
+            completion?(dto)
         }
     }
 

--- a/Routinus/Routinus/Data/UserRepository.swift
+++ b/Routinus/Routinus/Data/UserRepository.swift
@@ -16,7 +16,7 @@ protocol UserRepository {
               completion: ((UserDTO) -> Void)?)
     func fetchUser(by id: String,
                    completion: ((User) -> Void)?)
-    func updateContinuityDay(by id: String)
+    func updateContinuityDayByAuth(by id: String)
     func fetchThemeStyle() -> Int
     func updateUsername(of id: String,
                         name: String)
@@ -47,9 +47,9 @@ extension RoutinusRepository: UserRepository {
         }
     }
 
-    func updateContinuityDay(by id: String) {
-        RoutinusNetwork.updateContinuityDay(of: id,
-                                            completion: nil)
+    func updateContinuityDayByAuth(by id: String) {
+        RoutinusNetwork.updateContinuityDayByAuth(of: id,
+                                                  completion: nil)
     }
 
     func fetchThemeStyle() -> Int {

--- a/Routinus/Routinus/Domain/Usecase/UserCreateUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/UserCreateUsecase.swift
@@ -9,7 +9,7 @@ import CryptoKit
 import Foundation
 
 protocol UserCreatableUsecase {
-    func createUserID()
+    func createUser(completion: ((User) -> Void)?)
 }
 
 struct UserCreateUsecase: UserCreatableUsecase {
@@ -26,10 +26,13 @@ struct UserCreateUsecase: UserCreatableUsecase {
         return sha256.compactMap {String(format: "%02x", $0)}.joined()
     }
 
-    func createUserID() {
+    func createUser(completion: ((User) -> Void)?) {
         guard repository.isEmptyUserID() else { return }
         let id = createID()
         let name = UserNameFactory.createRandomName()
-        repository.save(id: id, name: name)
+        repository.save(id: id, name: name) { userDTO in
+            let user = User(userDTO: userDTO)
+            completion?(user)
+        }
     }
 }

--- a/Routinus/Routinus/Domain/Usecase/UserFetchUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/UserFetchUsecase.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 protocol UserFetchableUsecase {
-    func fetchUser(completion: @escaping (User) -> Void)
+    func fetchUser(id: String,
+                   completion: @escaping (User) -> Void)
     func fetchUserID() -> String?
     func fetchThemeStyle() -> Int
 }
@@ -20,9 +21,8 @@ struct UserFetchUsecase: UserFetchableUsecase {
         self.repository = repository
     }
 
-    func fetchUser(completion: @escaping (User) -> Void) {
-        guard let id = RoutinusRepository.userID() else { return }
-
+    func fetchUser(id: String,
+                   completion: @escaping (User) -> Void) {
         repository.fetchUser(by: id) { user in
             completion(user)
         }

--- a/Routinus/Routinus/Domain/Usecase/UserUpdateUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/UserUpdateUsecase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol UserUpdatableUsecase {
-    func updateContinuityDay()
+    func updateContinuityDayByAuth()
     func updateUsername(of id: String, name: String)
     func updateThemeStyle(_ style: Int)
 }
@@ -20,9 +20,9 @@ struct UserUpdateUsecase: UserUpdatableUsecase {
         self.repository = repository
     }
 
-    func updateContinuityDay() {
+    func updateContinuityDayByAuth() {
         guard let userID = RoutinusRepository.userID() else { return }
-        self.repository.updateContinuityDay(by: userID)
+        self.repository.updateContinuityDayByAuth(by: userID)
     }
 
     func updateUsername(of id: String,

--- a/Routinus/Routinus/Domain/Usecase/UserUpdateUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/UserUpdateUsecase.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 protocol UserUpdatableUsecase {
+    func updateContinuityDay(completion: ((User) -> Void)?)
     func updateContinuityDayByAuth()
     func updateUsername(of id: String, name: String)
     func updateThemeStyle(_ style: Int)
@@ -18,6 +19,14 @@ struct UserUpdateUsecase: UserUpdatableUsecase {
 
     init(repository: UserRepository) {
         self.repository = repository
+    }
+
+    func updateContinuityDay(completion: ((User) -> Void)?) {
+        guard let userID = RoutinusRepository.userID() else { return }
+        self.repository.updateContinuityDay(by: userID) { userDTO in
+            let user = User(userDTO: userDTO)
+            completion?(user)
+        }
     }
 
     func updateContinuityDayByAuth() {

--- a/Routinus/Routinus/Presentation/Auth/AuthViewModel.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewModel.swift
@@ -78,7 +78,7 @@ extension AuthViewModel {
                                                             userAuthThumbnailImageURL: userAuthThumbnailImageURL)
         self.participationUpdateUsecase.updateParticipationAuthCount(challengeID: challengeID)
         self.achievementUpdateUsecase.updateAchievementCount()
-        self.userUpdateUsecase.updateContinuityDay()
+        self.userUpdateUsecase.updateContinuityDayByAuth()
     }
 
     func didTappedAlertConfirm() {

--- a/Routinus/Routinus/Presentation/Home/Cells/RoutineTableViewCell.swift
+++ b/Routinus/Routinus/Presentation/Home/Cells/RoutineTableViewCell.swift
@@ -15,6 +15,7 @@ final class RoutineTableViewCell: UITableViewCell {
         progressView.layer.borderWidth = 5
         progressView.layer.cornerRadius = 25
         progressView.progress = 0.0
+        progressView.clipsToBounds = true
         progressView.trackTintColor = .systemBackground
         return progressView
     }()

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -182,7 +182,7 @@ extension HomeViewController: UITableViewDelegate {
         var auth = UIContextualAction()
         if viewModel.participationAuthStates[indexPath.item] == .authenticated {
             auth = UIContextualAction(style: .normal,
-                                      title: "certified".localized,
+                                      title: nil,
                                       handler: { _, _, _ in })
             auth.backgroundColor = UIColor(named: "LightGray")
             auth.title = "certified".localized

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -201,7 +201,6 @@ extension HomeViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView,
                    didSelectRowAt indexPath: IndexPath) {
-        guard let challengeID = viewModel?.todayRoutines.value[indexPath.row].challengeID else { return }
         self.viewModel?.didTappedTodayRoutine(index: indexPath.row)
     }
 }

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -180,21 +180,21 @@ extension HomeViewController: UITableViewDelegate {
                    trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         guard let viewModel = viewModel else { return nil }
         var auth = UIContextualAction()
-//        if viewModel.participationAuthStates[indexPath.item] == .authenticated {
-//            auth = UIContextualAction(style: .normal,
-//                                      title: "certified".localized,
-//                                      handler: { _, _, _ in })
-//            auth.backgroundColor = UIColor(named: "LightGray")
-//            auth.title = "certified".localized
-//        } else {
-//            auth = UIContextualAction(style: .normal,
-//                                      title: nil) { [weak self] (_, _, completion: @escaping (Bool) -> Void) in
-//                self?.viewModel?.didTappedTodayRoutineAuth(index: indexPath.row)
-//                completion(true)
-//            }
-//            auth.backgroundColor = UIColor(named: "MainColor")
-//            auth.title = "certify".localized
-//        }
+        if viewModel.participationAuthStates[indexPath.item] == .authenticated {
+            auth = UIContextualAction(style: .normal,
+                                      title: "certified".localized,
+                                      handler: { _, _, _ in })
+            auth.backgroundColor = UIColor(named: "LightGray")
+            auth.title = "certified".localized
+        } else {
+            auth = UIContextualAction(style: .normal,
+                                      title: nil) { [weak self] (_, _, completion: @escaping (Bool) -> Void) in
+                self?.viewModel?.didTappedTodayRoutineAuth(index: indexPath.row)
+                completion(true)
+            }
+            auth.backgroundColor = UIColor(named: "MainColor")
+            auth.title = "certify".localized
+        }
 
         return UISwipeActionsConfiguration(actions: [auth])
     }

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -144,18 +144,11 @@ extension HomeViewController {
     }
 
     private func configureDelegates() {
-        launchView.delegate = self
         todayRoutineView.delegate = self
         todayRoutineView.dataSource = dataSource
         todayRoutineView.challengeAddDelegate = self
         calendarView.delegate = self
         calendarView.dataSource = self
-    }
-}
-
-extension HomeViewController: LaunchViewDelegate {
-    func didStartedLaunchView() {
-        self.viewModel?.fetchMyHomeData()
     }
 }
 
@@ -185,12 +178,24 @@ extension HomeViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView,
                    trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        let auth = UIContextualAction(style: .normal, title: nil) { [weak self] (_, _, completion: @escaping (Bool) -> Void) in
-            self?.viewModel?.didTappedTodayRoutineAuth(index: indexPath.row)
-            completion(true)
-        }
-        auth.backgroundColor = UIColor(named: "MainColor")
-        auth.title = "certify".localized
+        guard let viewModel = viewModel else { return nil }
+        var auth = UIContextualAction()
+//        if viewModel.participationAuthStates[indexPath.item] == .authenticated {
+//            auth = UIContextualAction(style: .normal,
+//                                      title: "certified".localized,
+//                                      handler: { _, _, _ in })
+//            auth.backgroundColor = UIColor(named: "LightGray")
+//            auth.title = "certified".localized
+//        } else {
+//            auth = UIContextualAction(style: .normal,
+//                                      title: nil) { [weak self] (_, _, completion: @escaping (Bool) -> Void) in
+//                self?.viewModel?.didTappedTodayRoutineAuth(index: indexPath.row)
+//                completion(true)
+//            }
+//            auth.backgroundColor = UIColor(named: "MainColor")
+//            auth.title = "certify".localized
+//        }
+
         return UISwipeActionsConfiguration(actions: [auth])
     }
 

--- a/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
@@ -46,6 +46,7 @@ final class HomeViewModel: HomeViewModelIO {
 
     var userCreateUsecase: UserCreatableUsecase
     var userFetchUsecase: UserFetchableUsecase
+    var userUpdateUsecase: UserUpdatableUsecase
     var todayRoutineFetchUsecase: TodayRoutineFetchableUsecase
     var achievementFetchUsecase: AchievementFetchableUsecase
     var challengeAuthFetchUsecase: ChallengeAuthFetchableUsecase
@@ -60,11 +61,13 @@ final class HomeViewModel: HomeViewModelIO {
 
     init(userCreateUsecase: UserCreatableUsecase,
          userFetchUsecase: UserFetchableUsecase,
+         userUpdateUsecase: UserUpdatableUsecase,
          todayRoutineFetchUsecase: TodayRoutineFetchableUsecase,
          achievementFetchUsecase: AchievementFetchableUsecase,
          challengeAuthFetchUsecase: ChallengeAuthFetchableUsecase) {
         self.userCreateUsecase = userCreateUsecase
         self.userFetchUsecase = userFetchUsecase
+        self.userUpdateUsecase = userUpdateUsecase
         self.todayRoutineFetchUsecase = todayRoutineFetchUsecase
         self.achievementFetchUsecase = achievementFetchUsecase
         self.challengeAuthFetchUsecase = challengeAuthFetchUsecase
@@ -81,6 +84,7 @@ extension HomeViewModel {
         fetchUser()
         fetchTodayRoutine()
         fetchAchievement()
+        updateContinuityDay()
     }
 
     func didTappedTodayRoutine(index: Int) {
@@ -129,6 +133,12 @@ extension HomeViewModel {
     private func fetchAuth(challengeID: String, completion: @escaping (ChallengeAuth?) -> Void) {
         self.challengeAuthFetchUsecase.fetchChallengeAuth(challengeID: challengeID) { challengeAuth in
             completion(challengeAuth)
+        }
+    }
+
+    private func updateContinuityDay() {
+        self.userUpdateUsecase.updateContinuityDay { [weak self] user in
+            self?.user.value = user
         }
     }
 

--- a/Routinus/Routinus/Presentation/Home/Subviews/TodayRoutineView.swift
+++ b/Routinus/Routinus/Presentation/Home/Subviews/TodayRoutineView.swift
@@ -73,7 +73,6 @@ final class TodayRoutineView: UIView {
         tableView.removeLastAnchor()
         tableView.anchor(height: 60 * CGFloat(cellCount))
         tableView.layoutIfNeeded()
-        tableView.reloadData()
 
         let offset = cellCount == 0 ? addRoutineLabel.frame.height + 10 : CGFloat(60 * cellCount)
         anchor(height: 25 + offset)

--- a/Routinus/Routinus/Presentation/Launch/Subviews/LaunchVIew.swift
+++ b/Routinus/Routinus/Presentation/Launch/Subviews/LaunchVIew.swift
@@ -8,8 +8,6 @@
 import UIKit
 
 final class LaunchView: UIView {
-    weak var delegate: LaunchViewDelegate?
-
     private lazy var launchImageView: UIImageView = {
         let imageView = UIImageView(image: UIImage(named: "Logo"))
         imageView.contentMode = .scaleAspectFit
@@ -45,21 +43,10 @@ extension LaunchView {
     }
 
     private func animation() {
-        UIView.animate(withDuration: 0.5,
-                       animations: { },
-                       completion: { _ in
-            self.delegate?.didStartedLaunchView()
-            UIView.animate(withDuration: 0.5,
-                           animations: {
-                self.launchImageView.alpha = 0
-            },
-                           completion: { _ in
-                self.removeFromSuperview()
-            })
-        })
+        UIView.animate(withDuration: 0.5) {
+            self.launchImageView.alpha = 0
+        } completion: { _ in
+            self.removeFromSuperview()
+        }
     }
-}
-
-protocol LaunchViewDelegate: AnyObject {
-    func didStartedLaunchView()
 }

--- a/Routinus/Routinus/Presentation/MyPage/MyPageViewModel.swift
+++ b/Routinus/Routinus/Presentation/MyPage/MyPageViewModel.swift
@@ -41,7 +41,8 @@ final class MyPageViewModel: MyPageViewModelIO {
 
 extension MyPageViewModel {
     func fetchUserData() {
-        userFetchUsecase.fetchUser { [weak self] user in
+        guard let id = userFetchUsecase.fetchUserID() else { return }
+        userFetchUsecase.fetchUser(id: id) { [weak self] user in
             self?.user.value = user
         }
     }

--- a/Routinus/RoutinusNetwork/RoutinusNetwork.swift
+++ b/Routinus/RoutinusNetwork/RoutinusNetwork.swift
@@ -525,8 +525,8 @@ public enum RoutinusNetwork {
         }.resume()
     }
 
-    public static func updateContinuityDay(of id: String,
-                                           completion: (() -> Void)?) {
+    public static func updateContinuityDayByAuth(of id: String,
+                                                 completion: (() -> Void)?) {
         user(of: id) { dto in
             guard let document = dto.document,
                   let grade = Int(document.fields.grade.integerValue),

--- a/Routinus/RoutinusNetwork/RoutinusNetwork.swift
+++ b/Routinus/RoutinusNetwork/RoutinusNetwork.swift
@@ -24,9 +24,9 @@ public enum RoutinusNetwork {
 
     public static func insertUser(id: String,
                                   name: String,
-                                  completion: (() -> Void)?) {
+                                  completion: ((UserDTO?) -> Void)?) {
         guard let url = URL(string: "\(firestoreURL)/user") else {
-            completion?()
+            completion?(nil)
             return
         }
         var request = URLRequest(url: url)
@@ -35,7 +35,13 @@ public enum RoutinusNetwork {
         request.httpBody = UserQuery.insert(id: id, name: name)
 
         URLSession.shared.dataTask(with: request) { _, _, _ in
-            completion?()
+            let userDTO = UserDTO(id: id,
+                                  name: name,
+                                  grade: 0,
+                                  continuityDay: 0,
+                                  userImageCategoryID: "0",
+                                  lastAuthDay: "0")
+            completion?(userDTO)
         }.resume()
     }
 


### PR DESCRIPTION
## 관련 issue

Closes #287 

## 작업 내용

- [x] AppDelegate createUser 로직 제거
- [x] LaunchView animation fadeout만 적용, completion, delegate제거
- [x] UserDefaults에 id없을 시 user정보 만들고 바인딩
- [x] 오늘루틴셀 ClipToBounds설정
- [x] 오늘루틴셀 슬라이드시 인증한 챌린지는 인증하기 표시
- [x] lastAuthDay하루지나면 continuityDay 초기화 로직 설정


