### PR TITLE
[홈 화면] progressbar 애니메이션 임시 적용

### DIFF
--- a/Routinus/Routinus/Presentation/Home/Cells/RoutineTableViewCell.swift
+++ b/Routinus/Routinus/Presentation/Home/Cells/RoutineTableViewCell.swift
@@ -62,9 +62,15 @@ final class RoutineTableViewCell: UITableViewCell {
             categoryImageView.image = UIImage(systemName: routine.category.symbol)
         }
         categoryNameLabel.text = routine.title
-        progressView.progress = Float(routine.authCount) / Float(routine.totalCount)
         progressView.tintColor = UIColor(named: routine.category.color)
         progressView.layer.borderColor = UIColor(named: routine.category.color)?.cgColor
+
+        DispatchQueue.main.async {
+            UIView.animate(withDuration: 1.5, delay: 3) {
+                let progress = Float(routine.authCount) / Float(routine.totalCount)
+                self.progressView.setProgress(progress, animated: true)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## 작업 내용

- [x] progressbar 애니메이션 임시 적용

## 스크린 샷

https://user-images.githubusercontent.com/20144453/143013412-a61b6be6-d551-45bd-86fd-bca5c2298886.MP4

## 기타 사항

launchView의 시간을 고려하여 delay를 3초로 주었습니다.
인증하고 갔다와도 올라가는 애니메이션이 보이긴하지만,
fetch된 후 3초 후에 실행되는 것이기 때문에 바로 홈 화면에 오지 않으면 올라가는 애니메이션은 못볼 수 있을 것 같아요
