### PR TITLE
[인증화면] 인증사진 워터마크 유저닉네임 추가 및 Storage 저장 naming 수정

### DIFF
--- a/Routinus/Routinus/Application/Coordinator/AuthCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/AuthCoordinator.swift
@@ -29,6 +29,7 @@ final class AuthCoordinator: RoutinusCoordinator {
         let participationUpdateUsecase = ParticipationUpdateUsecase(repository: repository)
         let achievementUpdateUsecase = AchievementUpdateUsecase(repository: repository)
         let userUpdateUsecase = UserUpdateUsecase(repository: repository)
+        let userFetchUsecase = UserFetchUsecase(repository: repository)
         let authViewModel = AuthViewModel(challengeID: challengeID,
                                           challengeFetchUsecase: challengeFetchUsecase,
                                           imageFetchUsecase: imageFetchUsecase,
@@ -36,7 +37,8 @@ final class AuthCoordinator: RoutinusCoordinator {
                                           challengeAuthCreateUsecase: challengeAuthCreateUsecase,
                                           participationUpdateUsecase: participationUpdateUsecase,
                                           achievementUpdateUsecase: achievementUpdateUsecase,
-                                          userUpdateUsecase: userUpdateUsecase)
+                                          userUpdateUsecase: userUpdateUsecase,
+                                          userFetchUsecase: userFetchUsecase)
         let authViewController = AuthViewController(viewModel: authViewModel)
         authViewController.hidesBottomBarWhenPushed = true
         self.navigationController.pushViewController(authViewController, animated: true)

--- a/Routinus/Routinus/Data/ChallengeRepository.swift
+++ b/Routinus/Routinus/Data/ChallengeRepository.swift
@@ -84,8 +84,8 @@ extension RoutinusRepository: ChallengeRepository {
                                    challengeID: challengeID) { dto in
             let imageURL = RoutinusStorage.cachedImageURL(from: challengeID, filename: "image")
             let thumbnailImageURL = RoutinusStorage.cachedImageURL(from: challengeID, filename: "thumbnail_image")
-            let authExampleImageURL = RoutinusStorage.cachedImageURL(from: challengeID, filename: "auth")
-            let authExampleThumbnailImageURL = RoutinusStorage.cachedImageURL(from: challengeID, filename: "thumbnail_auth")
+            let authExampleImageURL = RoutinusStorage.cachedImageURL(from: challengeID, filename: "auth_method")
+            let authExampleThumbnailImageURL = RoutinusStorage.cachedImageURL(from: challengeID, filename: "thumbnail_auth_method")
             completion(Challenge(challengeDTO: dto,
                                  imageURL: imageURL,
                                  thumbnailImageURL: thumbnailImageURL,

--- a/Routinus/Routinus/Data/ImageRepository.swift
+++ b/Routinus/Routinus/Data/ImageRepository.swift
@@ -67,11 +67,11 @@ extension RoutinusRepository: ImageRepository {
                      authExampleImageURL: String,
                      authExampleThumbnailImageURL: String) {
         RoutinusNetwork.uploadImage(id: challengeID,
-                                    filename: "auth",
+                                    filename: "auth_method",
                                     imageURL: authExampleImageURL,
                                     completion: nil)
         RoutinusNetwork.uploadImage(id: challengeID,
-                                    filename: "thumbnail_auth",
+                                    filename: "thumbnail_auth_method",
                                     imageURL: authExampleThumbnailImageURL,
                                     completion: nil)
         RoutinusStorage.removeCachedImages(from: challengeID)

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -74,7 +74,8 @@ extension AuthViewController {
                               trailing: self.scrollView.trailingAnchor,
                               centerX: self.scrollView.centerXAnchor,
                               top: self.scrollView.topAnchor,
-                              bottom: self.scrollView.bottomAnchor, paddingBottom: 60)
+                              bottom: self.scrollView.bottomAnchor,
+                              paddingBottom: smallWidth ? 70 : 100)
 
         self.stackView.addArrangedSubview(authMethodView)
 

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -167,17 +167,18 @@ extension AuthViewController: UIImagePickerControllerDelegate, UINavigationContr
 
     func imagePickerController(_ picker: UIImagePickerController,
                                didFinishPickingMediaWithInfo info: [InfoKey: Any]) {
+        guard let viewModel = viewModel else { return }
         if let originalImage = info[InfoKey.originalImage] as? UIImage {
-            let timeAddedImage = originalImage.insertText(name: "",
+            let timeAddedImage = originalImage.insertText(name: viewModel.userName,
                                                           date: Date().toDateWithWeekdayString(),
                                                           time: Date().toTimeColonString())
             let mainImage = timeAddedImage.resizedImage(.original)
             let thumbnailImage = timeAddedImage.resizedImage(.thumbnail)
 
-            let mainImageURL = viewModel?.saveImage(to: "temp",
+            let mainImageURL = viewModel.saveImage(to: "temp",
                                                     filename: "auth",
                                                     data: mainImage.jpegData(compressionQuality: 0.9))
-            let thumbnailImageURL = viewModel?.saveImage(to: "temp",
+            let thumbnailImageURL = viewModel.saveImage(to: "temp",
                                                          filename: "thumbnail_auth",
                                                          data: thumbnailImage.jpegData(compressionQuality: 0.9))
             self.viewModel?.update(userAuthImageURL: mainImageURL)

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -96,7 +96,7 @@ extension AuthViewController {
                 self.navigationItem.title = challenge.title
                 self.authMethodView.update(to: challenge.authMethod)
                 self.viewModel?.imageData(from: challenge.challengeID,
-                                          filename: "thumbnail_auth",
+                                          filename: "thumbnail_auth_method",
                                           completion: { data in
                     guard let data = data else { return }
                     DispatchQueue.main.async {

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -155,7 +155,7 @@ extension AuthViewController: AuthMethodViewDelegate {
     func didTappedMethodImageView() {
         guard let challengeID = viewModel?.challenge.value?.challengeID else { return }
         self.viewModel?.imageData(from: challengeID,
-                                  filename: "auth") { data in
+                                  filename: "auth_method") { data in
             guard let data = data else { return }
             self.viewModel?.didTappedMethodImage(image: data)
         }
@@ -175,10 +175,10 @@ extension AuthViewController: UIImagePickerControllerDelegate, UINavigationContr
             let thumbnailImage = timeAddedImage.resizedImage(.thumbnail)
 
             let mainImageURL = viewModel?.saveImage(to: "temp",
-                                                    filename: "userAuth",
+                                                    filename: "auth",
                                                     data: mainImage.jpegData(compressionQuality: 0.9))
             let thumbnailImageURL = viewModel?.saveImage(to: "temp",
-                                                         filename: "thumbnail_userAuth",
+                                                         filename: "thumbnail_auth",
                                                          data: thumbnailImage.jpegData(compressionQuality: 0.9))
             self.viewModel?.update(userAuthImageURL: mainImageURL)
             self.viewModel?.update(userAuthThumbnailImageURL: thumbnailImageURL)

--- a/Routinus/Routinus/Presentation/Auth/AuthViewModel.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewModel.swift
@@ -27,6 +27,7 @@ protocol AuthViewModelOutput {
     var challenge: CurrentValueSubject<Challenge?, Never> { get }
     var alertConfirmTap: PassthroughSubject<Void, Never> { get }
     var methodImageTap: PassthroughSubject<Data, Never> { get }
+    var userName: String { get }
 }
 
 protocol AuthViewModelIO: AuthViewModelInput, AuthViewModelOutput { }
@@ -36,6 +37,7 @@ class AuthViewModel: AuthViewModelIO {
     var challenge = CurrentValueSubject<Challenge?, Never>(nil)
     var alertConfirmTap = PassthroughSubject<Void, Never>()
     var methodImageTap = PassthroughSubject<Data, Never>()
+    var userName: String = ""
     var challengeFetchUsecase: ChallengeFetchableUsecase
     var imageFetchUsecase: ImageFetchableUsecase
     var imageSaveUsecase: ImageSavableUsecase
@@ -43,6 +45,7 @@ class AuthViewModel: AuthViewModelIO {
     var participationUpdateUsecase: ParticipationUpdatableUsecase
     var achievementUpdateUsecase: AchievementUpdatableUsecase
     var userUpdateUsecase: UserUpdatableUsecase
+    var userFetchUsecase: UserFetchableUsecase
 
     private var challengeID: String
     private var userAuthImageURL: String
@@ -55,7 +58,8 @@ class AuthViewModel: AuthViewModelIO {
          challengeAuthCreateUsecase: ChallengeAuthCreatableUsecase,
          participationUpdateUsecase: ParticipationUpdatableUsecase,
          achievementUpdateUsecase: AchievementUpdatableUsecase,
-         userUpdateUsecase: UserUpdatableUsecase) {
+         userUpdateUsecase: UserUpdatableUsecase,
+         userFetchUsecase: UserFetchableUsecase) {
         self.challengeID = challengeID
         self.challengeFetchUsecase = challengeFetchUsecase
         self.imageFetchUsecase = imageFetchUsecase
@@ -64,9 +68,11 @@ class AuthViewModel: AuthViewModelIO {
         self.participationUpdateUsecase = participationUpdateUsecase
         self.achievementUpdateUsecase = achievementUpdateUsecase
         self.userUpdateUsecase = userUpdateUsecase
+        self.userFetchUsecase = userFetchUsecase
         self.userAuthImageURL = ""
         self.userAuthThumbnailImageURL = ""
         self.fetchChallenge(challengeID: challengeID)
+        self.fetchUsername()
     }
 
     private func validate() {
@@ -112,6 +118,13 @@ extension AuthViewModel {
 
     func saveImage(to directory: String, filename: String, data: Data?) -> String? {
         return imageSaveUsecase.saveImage(to: directory, filename: filename, data: data)
+    }
+    
+    func fetchUsername() {
+        guard let userID = userFetchUsecase.fetchUserID() else { return }
+        userFetchUsecase.fetchUser(id: userID) { [weak self] user in
+            self?.userName = user.name
+        }
     }
 }
 

--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -154,7 +154,7 @@ extension CreateViewController {
                 self.introductionView.update(introduction: challenge.introduction)
                 self.authMethodView.update(authMethod: challenge.authMethod)
                 self.viewModel?.imageData(from: challenge.challengeID,
-                                          filename: "thumbnail_auth",
+                                          filename: "thumbnail_auth_method",
                                           completion: { data in
                     guard let data = data, let image = UIImage(data: data) else { return }
                     DispatchQueue.main.async {

--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -364,10 +364,10 @@ extension CreateViewController: UIImagePickerControllerDelegate, UINavigationCon
                 imageRegisterView.setImage(thumbnailImage)
             case .authImage:
                 let mainImageURL = viewModel?.saveImage(to: "temp",
-                                                        filename: "auth",
+                                                        filename: "auth_method",
                                                         data: mainImage.jpegData(compressionQuality: 0.9))
                 let thumbnailImageURL = viewModel?.saveImage(to: "temp",
-                                                             filename: "thumbnail_auth",
+                                                             filename: "thumbnail_auth_method",
                                                              data: thumbnailImage.jpegData(compressionQuality: 0.9))
                 viewModel?.update(authExampleImageURL: mainImageURL)
                 viewModel?.update(authExampleThumbnailImageURL: thumbnailImageURL)

--- a/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
+++ b/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
@@ -125,7 +125,7 @@ final class DetailViewController: UIViewController {
                 self.informationView.update(to: challenge)
                 self.authMethodView.update(to: challenge.authMethod)
                 self.viewModel?.imageData(from: challenge.challengeID,
-                                          filename: "thumbnail_auth",
+                                          filename: "thumbnail_auth_method",
                                           completion: { data in
                     guard let data = data else { return }
                     DispatchQueue.main.async {

--- a/Routinus/RoutinusNetwork/RoutinusNetwork.swift
+++ b/Routinus/RoutinusNetwork/RoutinusNetwork.swift
@@ -94,12 +94,14 @@ public enum RoutinusNetwork {
 
         uploadQueue.async(group: group) {
             let id = challengeAuth.document?.fields.challengeID.stringValue ?? ""
+            let userID = challengeAuth.document?.fields.userID.stringValue ?? ""
+            let date = challengeAuth.document?.fields.date.stringValue ?? ""
             uploadImage(id: id,
-                        filename: "userAuth",
+                        filename: "\(userID)_\(date)_auth",
                         imageURL: userAuthImageURL,
                         completion: nil)
             uploadImage(id: id,
-                        filename: "thumbnail_userAuth",
+                        filename: "\(userID)_\(date)_thumbnail_auth",
                         imageURL: userAuthThumbnailImageURL,
                         completion: nil)
         }

--- a/Routinus/RoutinusNetwork/RoutinusNetwork.swift
+++ b/Routinus/RoutinusNetwork/RoutinusNetwork.swift
@@ -69,11 +69,11 @@ public enum RoutinusNetwork {
                         imageURL: thumbnailImageURL,
                         completion: nil)
             uploadImage(id: id,
-                        filename: "auth",
+                        filename: "auth_method",
                         imageURL: authExampleImageURL,
                         completion: nil)
             uploadImage(id: id,
-                        filename: "thumbnail_auth",
+                        filename: "thumbnail_auth_method",
                         imageURL: authExampleThumbnailImageURL,
                         completion: nil)
         }


### PR DESCRIPTION
## 관련 issue

Closes #174 

## 작업 내용

- [x] AuthViewModel userFetch 로직 추가
- [x] 인증사진 워터마크 유저닉네임 추가
- [x] 기존 이미지 저장 네이밍 수정 인증방법(auth -> auth_method, thumbnail_auth -> thumbnail_auth_method) 인증사진(auth)적용
- [x] 인증사진 Storage 디렉토리 구조 설정 challengeID\userID_20211123_auth.jpeg, challengeID\userID_20211123_thumbnail_auth.jpeg

