### PR TITLE
[챌린지 추가 화면] 스크롤 개선

### DIFF
--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -44,6 +44,7 @@ final class CreateViewController: UIViewController {
     private var cancellables = Set<AnyCancellable>()
     private var imagePicker = UIImagePickerController()
     private var selectedImagePickerTag: InputTag?
+    private var constraint: NSLayoutConstraint?
 
     init(with viewModel: CreateViewModelIO) {
         self.viewModel = viewModel
@@ -78,9 +79,13 @@ extension CreateViewController {
         scrollView.anchor(edges: view.safeAreaLayoutGuide)
 
         scrollView.addSubview(stackView)
+
         stackView.anchor(centerX: stackView.superview?.centerXAnchor,
                          horizontal: stackView.superview, paddingHorizontal: 20,
-                         vertical: stackView.superview, paddingVertical: 20)
+                         top: stackView.superview?.topAnchor, paddingTop: 20)
+        constraint = stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor,
+                                                       constant: 0)
+        constraint?.isActive = true
 
         stackView.addArrangedSubview(categoryView)
         stackView.addArrangedSubview(titleView)
@@ -187,11 +192,19 @@ extension CreateViewController {
     }
 
     @objc private func didShowKeyboard(_ notification: Notification) {
-        print(#function)
+        guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
+        let height = keyboardFrame.cgRectValue.height
+        constraint?.isActive = false
+        constraint = stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor,
+                                                       constant: -height)
+        constraint?.isActive = true
     }
 
     @objc private func willHideKeyboard(_ notification: Notification) {
-        print(#function)
+        self.constraint?.isActive = false
+        self.constraint = self.stackView.bottomAnchor.constraint(equalTo: self.scrollView.bottomAnchor,
+                                                                 constant: 0)
+        self.constraint?.isActive = true
     }
 }
 

--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -61,6 +61,7 @@ final class CreateViewController: UIViewController {
         configureViewModel()
         configureDelegates()
         configureGesture()
+        configureNotifications()
     }
 
     @objc private func didTappedCreateButton(_ sender: UIButton) {
@@ -172,6 +173,25 @@ extension CreateViewController {
         weekView.hideKeyboard()
         introductionView.hideKeyboard()
         authMethodView.hideKeyboard()
+    }
+
+    private func configureNotifications() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(didShowKeyboard),
+                                               name: UIResponder.keyboardDidShowNotification,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(willHideKeyboard),
+                                               name: UIResponder.keyboardWillHideNotification,
+                                               object: nil)
+    }
+
+    @objc private func didShowKeyboard(_ notification: Notification) {
+        print(#function)
+    }
+
+    @objc private func willHideKeyboard(_ notification: Notification) {
+        print(#function)
     }
 }
 

--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -226,13 +226,13 @@ extension CreateViewController: CreateSubviewDelegate {
 
 extension CreateViewController: UITextFieldDelegate, UITextViewDelegate {
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        guard let tag = InputTag(rawValue: textField.tag) else { return }
-        scrollView.setContentOffset(CGPoint(x: 0, y: tag.offset), animated: true)
+        guard let offset = textField.superview?.frame.origin.y else { return }
+        scrollView.setContentOffset(CGPoint(x: 0, y: offset), animated: true)
     }
 
     func textViewDidBeginEditing(_ textView: UITextView) {
-        guard let tag = InputTag(rawValue: textView.tag) else { return }
-        scrollView.setContentOffset(CGPoint(x: 0, y: tag.offset), animated: true)
+        guard let offset = textView.superview?.frame.origin.y else { return }
+        scrollView.setContentOffset(CGPoint(x: 0, y: offset), animated: true)
     }
 
     func textFieldDidChangeSelection(_ textField: UITextField) {

--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -11,21 +11,6 @@ import UIKit
 final class CreateViewController: UIViewController {
     enum InputTag: Int {
         case category = 0, title, image, week, introduction, authMethod, authImage
-
-        var offset: Int {
-            switch self {
-            case .title:
-                return 130
-            case .week:
-                return 530
-            case .introduction:
-                return 750
-            case .authMethod:
-                return 1015
-            default:
-                return 0
-            }
-        }
     }
 
     private lazy var scrollView: UIScrollView = UIScrollView()

--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -194,6 +194,7 @@ extension CreateViewController {
     @objc private func didShowKeyboard(_ notification: Notification) {
         guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         let height = keyboardFrame.cgRectValue.height
+        
         constraint?.isActive = false
         constraint = stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor,
                                                        constant: -height)
@@ -201,10 +202,25 @@ extension CreateViewController {
     }
 
     @objc private func willHideKeyboard(_ notification: Notification) {
-        self.constraint?.isActive = false
-        self.constraint = self.stackView.bottomAnchor.constraint(equalTo: self.scrollView.bottomAnchor,
-                                                                 constant: 0)
-        self.constraint?.isActive = true
+        guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
+        let height = keyboardFrame.cgRectValue.height
+        let stackViewHeight = stackView.frame.size.height
+        let scrollViewHeight = scrollView.frame.size.height
+        let animationCallOffset = stackViewHeight - scrollViewHeight
+
+        if scrollView.contentOffset.y > animationCallOffset {
+            DispatchQueue.main.async {
+                UIView.animate(withDuration: 0.5) {
+                    self.scrollView.setContentOffset(CGPoint(x: 0, y: animationCallOffset + 20),
+                                                     animated: false)
+                } completion: { _ in
+                    self.constraint?.isActive = false
+                    self.constraint = self.stackView.bottomAnchor.constraint(equalTo: self.scrollView.bottomAnchor,
+                                                                             constant: 0)
+                    self.constraint?.isActive = true
+                }
+            }
+        }
     }
 }
 

--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -212,12 +212,20 @@ extension CreateViewController: CreateSubviewDelegate {
 extension CreateViewController: UITextFieldDelegate, UITextViewDelegate {
     func textFieldDidBeginEditing(_ textField: UITextField) {
         guard let offset = textField.superview?.frame.origin.y else { return }
-        scrollView.setContentOffset(CGPoint(x: 0, y: offset), animated: true)
+        DispatchQueue.main.async {
+            UIView.animate(withDuration: 0.5) {
+                self.scrollView.setContentOffset(CGPoint(x: 0, y: offset), animated: false)
+            }
+        }
     }
 
     func textViewDidBeginEditing(_ textView: UITextView) {
         guard let offset = textView.superview?.frame.origin.y else { return }
-        scrollView.setContentOffset(CGPoint(x: 0, y: offset), animated: true)
+        DispatchQueue.main.async {
+            UIView.animate(withDuration: 0.5) {
+                self.scrollView.setContentOffset(CGPoint(x: 0, y: offset), animated: false)
+            }
+        }
     }
 
     func textFieldDidChangeSelection(_ textField: UITextField) {


### PR DESCRIPTION
## 관련 issue

close #203 

## 작업 내용

- [x] 디바이스에 관계없이 스크롤 동작하도록 개선
- [x] 고정된 offset 프로퍼티 제거
- [x] 애니메이션 직접 지정하여 프레임 드랍 줄임
- [x] 키보드 이슈 해결

## 스크린 샷

https://user-images.githubusercontent.com/20144453/143204326-91030b71-da59-4b27-afda-b2f317c290e7.MP4

## 기타 사항

기존에 고정된 offset을 지정해놓았더니 디바이스에 따라 결과가 달라지는 버그가 있었습니다.
고정된 offset을 삭제하고, frame.size에 접근하여 동적으로 계산하도록 변경했습니다.

기존에 스크롤될 때 잡렉?이 좀 심했는데, 애니메이션을 직접 지정해서 프레임 드랍을 좀 줄였습니다. (아예 없진 않네요)

~+) #203 이 이슈 어떤 내용인지 자세히 설명해주실 수 있으신 분 !? 재연이 안됩니다.. ㅠ~
해결했습니다 !