### PR TITLE
[홈 화면, 마이페이지] UIRefreshControl 프로토타입 구현

### DIFF
--- a/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
+++ b/Routinus/Routinus/Application/Coordinator/HomeCoordinator.swift
@@ -18,6 +18,8 @@ final class HomeCoordinator: RoutinusCoordinator {
                                                                       object: nil)
     let createPublisher = NotificationCenter.default.publisher(for: CreateCoordinator.confirmCreate,
                                                                object: nil)
+    let usernamePublisher = NotificationCenter.default.publisher(for: UserUpdateUsecase.didUpdateUsername,
+                                                                 object: nil)
 
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController
@@ -84,6 +86,13 @@ final class HomeCoordinator: RoutinusCoordinator {
             .receive(on: RunLoop.main)
             .sink { _ in
                 homeViewModel.fetchMyHomeData()
+            }
+            .store(in: &cancellables)
+
+        self.usernamePublisher
+            .receive(on: RunLoop.main)
+            .sink { _ in
+                homeViewModel.addRefreshIndicator()
             }
             .store(in: &cancellables)
 

--- a/Routinus/Routinus/Domain/Usecase/UserUpdateUsecase.swift
+++ b/Routinus/Routinus/Domain/Usecase/UserUpdateUsecase.swift
@@ -15,6 +15,8 @@ protocol UserUpdatableUsecase {
 }
 
 struct UserUpdateUsecase: UserUpdatableUsecase {
+    static let didUpdateUsername = Notification.Name("didUpdateUsername")
+
     var repository: UserRepository
 
     init(repository: UserRepository) {
@@ -38,6 +40,8 @@ struct UserUpdateUsecase: UserUpdatableUsecase {
                         name: String) {
         self.repository.updateUsername(of: id,
                                        name: name)
+        NotificationCenter.default.post(name: UserUpdateUsecase.didUpdateUsername,
+                                        object: nil)
     }
 
     func updateThemeStyle(_ style: Int) {

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -155,11 +155,12 @@ extension HomeViewController {
     private func configureRefreshControl() {
         self.scrollView.refreshControl = UIRefreshControl()
         self.scrollView.refreshControl?.addTarget(self,
-                                                  action: #selector(test),
+                                                  action: #selector(refresh),
                                                   for: .valueChanged)
     }
 
-    @objc private func test() {
+    @objc private func refresh() {
+        self.viewModel?.fetchMyHomeData()
         self.scrollView.refreshControl?.endRefreshing()
     }
 }

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -49,6 +49,7 @@ final class HomeViewController: UIViewController {
         configureViews()
         configureViewModel()
         configureDelegates()
+        configureRefreshControl()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -149,6 +150,17 @@ extension HomeViewController {
         todayRoutineView.challengeAddDelegate = self
         calendarView.delegate = self
         calendarView.dataSource = self
+    }
+
+    private func configureRefreshControl() {
+        self.scrollView.refreshControl = UIRefreshControl()
+        self.scrollView.refreshControl?.addTarget(self,
+                                                  action: #selector(test),
+                                                  for: .valueChanged)
+    }
+
+    @objc private func test() {
+        self.scrollView.refreshControl?.endRefreshing()
     }
 }
 

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -120,8 +120,8 @@ extension HomeViewController {
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] hasIndicator in
                 guard let self = self else { return }
-                let systemName = hasIndicator ? "square.and.arrow.down" : "arrow.clockwise"
-                self.navigationItem.rightBarButtonItem?.image = UIImage(systemName: systemName)
+                let named = hasIndicator ? "Red" : "Black"
+                self.navigationItem.rightBarButtonItem?.tintColor = UIColor(named: named)
             })
             .store(in: &cancellables)
 

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -107,9 +107,20 @@ extension HomeViewController {
     }
 
     private func configureNavigationBar() {
-        let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
+        let backBarButtonItem = UIBarButtonItem(title: "",
+                                                style: .plain,
+                                                target: self,
+                                                action: nil)
         backBarButtonItem.tintColor = UIColor(named: "Black")
         self.navigationItem.backBarButtonItem = backBarButtonItem
+
+        let refreshBarButtonItem = UIBarButtonItem(title: "",
+                                                   style: .plain,
+                                                   target: self,
+                                                   action: #selector(refresh))
+        refreshBarButtonItem.image = UIImage(systemName: "arrow.clockwise")
+        refreshBarButtonItem.tintColor = UIColor(named: "Black")
+        self.navigationItem.rightBarButtonItem = refreshBarButtonItem
     }
 
     private func configureViewModel() {

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -116,6 +116,15 @@ extension HomeViewController {
     }
 
     private func configureViewModel() {
+        self.viewModel?.hasRefreshIndicator
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] hasIndicator in
+                guard let self = self else { return }
+                let systemName = hasIndicator ? "square.and.arrow.down" : "arrow.clockwise"
+                self.navigationItem.rightBarButtonItem?.image = UIImage(systemName: systemName)
+            })
+            .store(in: &cancellables)
+
         self.viewModel?.user
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] user in
@@ -164,6 +173,7 @@ extension HomeViewController {
 
     @objc private func refresh() {
         self.viewModel?.fetchMyHomeData()
+        self.viewModel?.removeRefreshIndicator()
         self.scrollView.refreshControl?.endRefreshing()
     }
 }

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -75,7 +75,7 @@ extension HomeViewController {
 
         self.contentView.addSubview(titleLabel)
         titleLabel.anchor(horizontal: titleLabel.superview, paddingHorizontal: offset,
-                          top: titleLabel.superview?.topAnchor, paddingTop: smallWidth ? 28 : 32,
+                          top: titleLabel.superview?.topAnchor,
                           height: 80)
 
         self.contentView.addSubview(continuityView)

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -51,14 +51,6 @@ final class HomeViewController: UIViewController {
         configureDelegates()
         configureRefreshControl()
     }
-
-    override func viewWillAppear(_ animated: Bool) {
-        self.navigationController?.setNavigationBarHidden(true, animated: animated)
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        self.navigationController?.setNavigationBarHidden(false, animated: animated)
-    }
 }
 
 extension HomeViewController {

--- a/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
@@ -15,6 +15,8 @@ protocol HomeViewModelInput {
     func didTappedTodayRoutineAuth(index: Int)
     func generateDaysInMonth(for baseDate: Date) -> [Day]
     func changeDate(month: Int)
+    func addRefreshIndicator()
+    func removeRefreshIndicator()
 }
 
 protocol HomeViewModelOutput {
@@ -26,6 +28,7 @@ protocol HomeViewModelOutput {
     var todayRoutineTap: PassthroughSubject<String, Never> { get }
     var todayRoutineAuthTap: PassthroughSubject<String, Never> { get }
     var baseDate: CurrentValueSubject<Date, Never> { get }
+    var hasRefreshIndicator: CurrentValueSubject<Bool, Never> { get }
     var days: CurrentValueSubject<[Day], Never> { get }
     var calendar: Calendar { get }
     var selectedDates: [Date] { get }
@@ -52,6 +55,7 @@ final class HomeViewModel: HomeViewModelIO {
     var challengeAuthFetchUsecase: ChallengeAuthFetchableUsecase
     var cancellables = Set<AnyCancellable>()
 
+    var hasRefreshIndicator = CurrentValueSubject<Bool, Never>(false)
     var days = CurrentValueSubject<[Day], Never>([])
     var baseDate = CurrentValueSubject<Date, Never>(Date())
     var calendar = Calendar(identifier: .gregorian)
@@ -99,6 +103,14 @@ extension HomeViewModel {
     func didTappedTodayRoutineAuth(index: Int) {
         let challengeID = self.todayRoutines.value[index].challengeID
         self.todayRoutineAuthTap.send(challengeID)
+    }
+
+    func addRefreshIndicator() {
+        self.hasRefreshIndicator.value = true
+    }
+
+    func removeRefreshIndicator() {
+        self.hasRefreshIndicator.value = false
     }
 }
 

--- a/Routinus/Routinus/Resources/Assets.xcassets/colors/Red.colorset/Contents.json
+++ b/Routinus/Routinus/Resources/Assets.xcassets/colors/Red.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.467",
+          "green" : "0.467",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.467",
+          "green" : "0.467",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## 작업 내용

- [x] 홈 화면 UIRefreshControl 구현(스와이프하여 새로고침)
- [x] 홈 화면 NavigationBar 항상 보이도록 수정, 그에 따른 레이아웃 조정
- [x] NavigationBar RightItem으로 Refresh 버튼 생성
- [x] 마이페이지에서 Username 수정하면 Refresh color를 Red로 변경하고, fetch하면 다시 Black으로 변경하도록 구현

## 스크린 샷

https://user-images.githubusercontent.com/20144453/143283539-fdac9680-bd5b-4883-bd6b-c231aa8f7c0a.MP4

## 기타 사항

새로고침 모양에 점 찍혀있는 아이콘으로 바꾸고싶었는데 이쁘게 안나와서 일단 tintColor로 구분하는 걸로 임시 구현했습니다.
