### PR TITLE
[홈 화면] 캘린더 셀 사이즈 깨지는 이슈 해결

### DIFF
--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -31,7 +31,6 @@ final class HomeViewController: UIViewController {
 
     private var viewModel: HomeViewModelIO?
     private var cancellables = Set<AnyCancellable>()
-    private var achievements = [Achievement]()
 
     init(with viewModel: HomeViewModelIO) {
         self.viewModel = viewModel
@@ -251,8 +250,8 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let width = Int(collectionView.frame.width / 7)
-        let height = 55
+        let width = CGFloat(collectionView.frame.width / 7) - 0.5
+        let height = 55.0
         return CGSize(width: width, height: height)
     }
 }

--- a/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
@@ -14,7 +14,6 @@ protocol HomeViewModelInput {
     func didTappedAddChallengeButton()
     func didTappedTodayRoutineAuth(index: Int)
     func didTappedExplanationButton()
-    func generateDaysInMonth(for baseDate: Date) -> [Day]
     func changeDate(month: Int)
 }
 

--- a/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewModel.swift
@@ -22,7 +22,6 @@ protocol HomeViewModelOutput {
     var user: CurrentValueSubject<User, Never> { get }
     var todayRoutines: CurrentValueSubject<[TodayRoutine], Never> { get }
     var participationAuthStates: [ParticipationAuthState] { get }
-    var achievements: [Achievement] { get }
     var challengeAddButtonTap: PassthroughSubject<Void, Never> { get }
     var todayRoutineTap: PassthroughSubject<String, Never> { get }
     var todayRoutineAuthTap: PassthroughSubject<String, Never> { get }


### PR DESCRIPTION
## 관련 issue

close #313 

## 작업 내용

<img width="482" alt="스크린샷 2021-11-26 오후 8 55 16" src="https://user-images.githubusercontent.com/37893327/143663217-43420218-9ac0-42df-9d73-483788e99f2c.png">

- [x] 셀 크기 -0.5 해서 안 깨지도록 수정
