### PR TITLE
[전체 화면] UIRefreshControl 잔상 이슈 해결

### DIFF
--- a/Routinus/Routinus.xcodeproj/project.pbxproj
+++ b/Routinus/Routinus.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		44AAA2C1272FDF8F002E16C4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 44AAA2BF272FDF8F002E16C4 /* LaunchScreen.storyboard */; };
 		44AAA2CA272FE13D002E16C4 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 44AAA2C9272FE13D002E16C4 /* .swiftlint.yml */; };
 		44AAA3242733819B002E16C4 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44AAA3232733819B002E16C4 /* Date+Extensions.swift */; };
+		44EA8A262751FF5D00861183 /* UIScrollView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44EA8A252751FF5D00861183 /* UIScrollView+Extensions.swift */; };
 		8956F624DD102BDACEAB1C4F /* Pods_Routinus.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BC6FF3CC2926D6BD45C0ED2 /* Pods_Routinus.framework */; };
 		E901EFD42744BD3400B14847 /* ImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E901EFD32744BD3400B14847 /* ImageRepository.swift */; };
 		E901EFD62744BDBD00B14847 /* ImageFetchUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E901EFD52744BDBD00B14847 /* ImageFetchUsecase.swift */; };
@@ -285,6 +286,7 @@
 		44AAA2C2272FDF8F002E16C4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		44AAA2C9272FE13D002E16C4 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		44AAA3232733819B002E16C4 /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
+		44EA8A252751FF5D00861183 /* UIScrollView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+Extensions.swift"; sourceTree = "<group>"; };
 		5BC6FF3CC2926D6BD45C0ED2 /* Pods_Routinus.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Routinus.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E901EFD32744BD3400B14847 /* ImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepository.swift; sourceTree = "<group>"; };
 		E901EFD52744BDBD00B14847 /* ImageFetchUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFetchUsecase.swift; sourceTree = "<group>"; };
@@ -648,6 +650,7 @@
 				0DC38F58273BA89000331C25 /* UIImage+Extensions.swift */,
 				0DFF32BC274548D8004FA9BD /* UIView+Extensions.swift */,
 				14BFC0E0274E106D00A982CB /* UICollectionView+Extensions.swift */,
+				44EA8A252751FF5D00861183 /* UIScrollView+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1217,6 +1220,7 @@
 				441CEE11273A332D006C261F /* CreateCategoryView.swift in Sources */,
 				1483873C2743F2FF00731F98 /* ParticipantButton.swift in Sources */,
 				14BFC0DA274DB7E100A982CB /* AuthImagesViewModel.swift in Sources */,
+				44EA8A262751FF5D00861183 /* UIScrollView+Extensions.swift in Sources */,
 				14BFC0DC274DBBF100A982CB /* AuthImagesViewController.swift in Sources */,
 				E9B1298227336EE50072D254 /* TodayRoutine.swift in Sources */,
 				0DBBAA3727341C1600B32EB5 /* ChallengeCollectionViewLayouts.swift in Sources */,

--- a/Routinus/Routinus/Extensions/UIScrollView+Extensions.swift
+++ b/Routinus/Routinus/Extensions/UIScrollView+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  UIScrollView+Extensions.swift
+//  Routinus
+//
+//  Created by 유석환 on 2021/11/27.
+//
+
+import UIKit
+
+extension UIScrollView {
+    func removeAfterimage() {
+        self.refreshControl?.beginRefreshing()
+        self.refreshControl?.endRefreshing()
+    }
+}

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -40,7 +40,6 @@ final class AuthViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         configureViews()
         configureViewModel()
         configureDelegates()

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -46,6 +46,11 @@ final class AuthViewController: UIViewController {
         configureDelegates()
         configureRefreshControl()
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.scrollView.removeAfterimage()
+    }
 }
 
 extension AuthViewController {

--- a/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
+++ b/Routinus/Routinus/Presentation/Auth/AuthViewController.swift
@@ -129,13 +129,13 @@ extension AuthViewController {
     private func configureRefreshControl() {
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self,
-                           action: #selector(refresh),
-                           for: .valueChanged)
-        refreshControl.attributedTitle = NSAttributedString(string: "swipe".localized,
-                                                     attributes: [NSAttributedString.Key.foregroundColor:
-                                                                    UIColor.systemGray,
-                                                                  NSAttributedString.Key.font:
-                                                                    UIFont.boldSystemFont(ofSize: 20)])
+                                 action: #selector(refresh),
+                                 for: .valueChanged)
+        refreshControl.attributedTitle = NSAttributedString(
+            string: "swipe".localized,
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.systemGray,
+                         NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 20)]
+        )
         self.scrollView.refreshControl = refreshControl
     }
 

--- a/Routinus/Routinus/Presentation/AuthImages/AuthImagesViewController.swift
+++ b/Routinus/Routinus/Presentation/AuthImages/AuthImagesViewController.swift
@@ -31,7 +31,6 @@ class AuthImagesViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         configureViews()
         configureDelegates()
         configureViewModel()

--- a/Routinus/Routinus/Presentation/AuthImages/AuthImagesViewController.swift
+++ b/Routinus/Routinus/Presentation/AuthImages/AuthImagesViewController.swift
@@ -37,6 +37,11 @@ class AuthImagesViewController: UIViewController {
         configureViewModel()
         configureRefreshControl()
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.collectionView.removeAfterimage()
+    }
 }
 
 extension AuthImagesViewController {

--- a/Routinus/Routinus/Presentation/AuthImages/AuthImagesViewController.swift
+++ b/Routinus/Routinus/Presentation/AuthImages/AuthImagesViewController.swift
@@ -84,13 +84,13 @@ extension AuthImagesViewController {
     private func configureRefreshControl() {
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self,
-                           action: #selector(refresh),
-                           for: .valueChanged)
-        refreshControl.attributedTitle = NSAttributedString(string: "swipe".localized,
-                                                     attributes: [NSAttributedString.Key.foregroundColor:
-                                                                    UIColor.systemGray,
-                                                                  NSAttributedString.Key.font:
-                                                                    UIFont.boldSystemFont(ofSize: 20)])
+                                 action: #selector(refresh),
+                                 for: .valueChanged)
+        refreshControl.attributedTitle = NSAttributedString(
+            string: "swipe".localized,
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.systemGray,
+                         NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 20)]
+        )
         self.collectionView.refreshControl = refreshControl
     }
 

--- a/Routinus/Routinus/Presentation/Challenge/ChallengeViewController.swift
+++ b/Routinus/Routinus/Presentation/Challenge/ChallengeViewController.swift
@@ -76,6 +76,7 @@ final class ChallengeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.setNavigationBarHidden(true, animated: animated)
+        self.collectionView.removeAfterimage()
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/Routinus/Routinus/Presentation/Challenge/ChallengeViewController.swift
+++ b/Routinus/Routinus/Presentation/Challenge/ChallengeViewController.swift
@@ -189,13 +189,13 @@ extension ChallengeViewController {
     private func configureRefreshControl() {
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self,
-                           action: #selector(refresh),
-                           for: .valueChanged)
-        refreshControl.attributedTitle = NSAttributedString(string: "swipe".localized,
-                                                     attributes: [NSAttributedString.Key.foregroundColor:
-                                                                    UIColor.systemGray,
-                                                                  NSAttributedString.Key.font:
-                                                                    UIFont.boldSystemFont(ofSize: 20)])
+                                 action: #selector(refresh),
+                                 for: .valueChanged)
+        refreshControl.attributedTitle = NSAttributedString(
+            string: "swipe".localized,
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.systemGray,
+                         NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 20)]
+        )
         self.collectionView.refreshControl = refreshControl
     }
 

--- a/Routinus/Routinus/Presentation/Create/CreateViewController.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewController.swift
@@ -57,7 +57,6 @@ final class CreateViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         configureViews()
         configureViewModel()
         configureDelegates()

--- a/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
+++ b/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
@@ -57,6 +57,11 @@ final class DetailViewController: UIViewController {
         self.configureRefreshControl()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.scrollView.removeAfterimage()
+    }
+
     init(with viewModel: DetailViewModelIO) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)

--- a/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
+++ b/Routinus/Routinus/Presentation/Detail/DetailViewController.swift
@@ -181,13 +181,13 @@ final class DetailViewController: UIViewController {
     private func configureRefreshControl() {
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self,
-                           action: #selector(refresh),
-                           for: .valueChanged)
-        refreshControl.attributedTitle = NSAttributedString(string: "swipe".localized,
-                                                     attributes: [NSAttributedString.Key.foregroundColor:
-                                                                    UIColor.systemGray,
-                                                                  NSAttributedString.Key.font:
-                                                                    UIFont.boldSystemFont(ofSize: 20)])
+                                 action: #selector(refresh),
+                                 for: .valueChanged)
+        refreshControl.attributedTitle = NSAttributedString(
+            string: "swipe".localized,
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.systemGray,
+                         NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 20)]
+        )
         self.scrollView.refreshControl = refreshControl
     }
 

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -52,11 +52,13 @@ final class HomeViewController: UIViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         self.navigationController?.setNavigationBarHidden(true, animated: animated)
         self.scrollView.removeAfterimage()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
     }
 }

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -54,6 +54,7 @@ final class HomeViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         self.navigationController?.setNavigationBarHidden(true, animated: animated)
+        self.scrollView.removeAfterimage()
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -158,13 +158,13 @@ extension HomeViewController {
     private func configureRefreshControl() {
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self,
-                           action: #selector(refresh),
-                           for: .valueChanged)
-        refreshControl.attributedTitle = NSAttributedString(string: "swipe".localized,
-                                                     attributes: [NSAttributedString.Key.foregroundColor:
-                                                                    UIColor.systemGray,
-                                                                  NSAttributedString.Key.font:
-                                                                    UIFont.boldSystemFont(ofSize: 16)])
+                                 action: #selector(refresh),
+                                 for: .valueChanged)
+        refreshControl.attributedTitle = NSAttributedString(
+            string: "swipe".localized,
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.systemGray,
+                         NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 16)]
+        )
         self.scrollView.refreshControl = refreshControl
     }
 

--- a/Routinus/Routinus/Presentation/Home/HomeViewController.swift
+++ b/Routinus/Routinus/Presentation/Home/HomeViewController.swift
@@ -44,7 +44,6 @@ final class HomeViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         configureLaunchView()
         configureViews()
         configureViewModel()

--- a/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
+++ b/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
@@ -141,13 +141,13 @@ extension ManageViewController {
     private func configureRefreshControl() {
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self,
-                           action: #selector(refresh),
-                           for: .valueChanged)
-        refreshControl.attributedTitle = NSAttributedString(string: "swipe".localized,
-                                                     attributes: [NSAttributedString.Key.foregroundColor:
-                                                                    UIColor.systemGray,
-                                                                  NSAttributedString.Key.font:
-                                                                    UIFont.boldSystemFont(ofSize: 20)])
+                                 action: #selector(refresh),
+                                 for: .valueChanged)
+        refreshControl.attributedTitle = NSAttributedString(
+            string: "swipe".localized,
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.systemGray,
+                         NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 20)]
+        )
         self.collectionView.refreshControl = refreshControl
     }
 

--- a/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
+++ b/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
@@ -60,11 +60,13 @@ final class ManageViewController: UIViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         self.navigationController?.setNavigationBarHidden(true, animated: animated)
         self.collectionView.removeAfterimage()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
     }
 }

--- a/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
+++ b/Routinus/Routinus/Presentation/Manage/ManageViewController.swift
@@ -61,6 +61,7 @@ final class ManageViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         self.navigationController?.setNavigationBarHidden(true, animated: animated)
+        self.collectionView.removeAfterimage()
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/Routinus/Routinus/Presentation/MyPage/MyPageViewController.swift
+++ b/Routinus/Routinus/Presentation/MyPage/MyPageViewController.swift
@@ -62,10 +62,12 @@ final class MyPageViewController: UIViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         self.navigationController?.setNavigationBarHidden(true, animated: animated)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
     }
 }

--- a/Routinus/Routinus/Presentation/MyPage/MyPageViewController.swift
+++ b/Routinus/Routinus/Presentation/MyPage/MyPageViewController.swift
@@ -56,7 +56,6 @@ final class MyPageViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         configureViews()
         configureDelegates()
         configureViewModel()

--- a/Routinus/Routinus/Presentation/Search/SearchViewController.swift
+++ b/Routinus/Routinus/Presentation/Search/SearchViewController.swift
@@ -183,13 +183,13 @@ extension SearchViewController {
     private func configureRefreshControl() {
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self,
-                           action: #selector(refresh),
-                           for: .valueChanged)
-        refreshControl.attributedTitle = NSAttributedString(string: "swipe".localized,
-                                                     attributes: [NSAttributedString.Key.foregroundColor:
-                                                                    UIColor.systemGray,
-                                                                  NSAttributedString.Key.font:
-                                                                    UIFont.boldSystemFont(ofSize: 20)])
+                                 action: #selector(refresh),
+                                 for: .valueChanged)
+        refreshControl.attributedTitle = NSAttributedString(
+            string: "swipe".localized,
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.systemGray,
+                         NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 20)]
+        )
         self.collectionView.refreshControl = refreshControl
     }
 

--- a/Routinus/Routinus/Presentation/Search/SearchViewController.swift
+++ b/Routinus/Routinus/Presentation/Search/SearchViewController.swift
@@ -73,6 +73,11 @@ final class SearchViewController: UIViewController {
         self.configureRefreshControl()
         self.didLoadedSearchView()
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.collectionView.removeAfterimage()
+    }
 }
 
 extension SearchViewController {


### PR DESCRIPTION
## 관련 issue

close #315 

## 스크린샷

https://user-images.githubusercontent.com/20144453/143670545-0f48f286-7e48-4b44-8713-da33b455f7e8.MP4

## 작업 내용

- [x] 스크롤 도중 다른 탭 갔다오면 잔상이 남아있는 이슈 해결
- [x] Lifecycle 메소드들의 개행 방식 통일
- [x] Lifecycle 메소드들 중 super 메소드 호출하지 않는 부분 수정
