### PR TITLE
[챌린지 생성 화면, 마이페이지 화면] 챌린지 수정 생성 or 닉네임 변경할 때 공백만 들어가는 경우 수정 or 생성 안되게 하기  

### DIFF
--- a/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
+++ b/Routinus/Routinus/Presentation/Create/CreateViewModel.swift
@@ -123,7 +123,7 @@ extension CreateViewModel {
     }
 
     func update(title: String) {
-        self.title = title
+        self.title = title.trimmingCharacters(in: .whitespacesAndNewlines)
         self.validate()
     }
 
@@ -146,12 +146,12 @@ extension CreateViewModel {
     }
 
     func update(introduction: String) {
-        self.introduction = introduction
+        self.introduction = introduction.trimmingCharacters(in: .whitespacesAndNewlines)
         self.validate()
     }
 
     func update(authMethod: String) {
-        self.authMethod = authMethod
+        self.authMethod = authMethod.trimmingCharacters(in: .whitespacesAndNewlines)
         self.validate()
     }
 

--- a/Routinus/Routinus/Presentation/MyPage/MyPageViewController.swift
+++ b/Routinus/Routinus/Presentation/MyPage/MyPageViewController.swift
@@ -154,7 +154,7 @@ extension MyPageViewController: MyPageUserNameUpdatableDelegate, UITextFieldDele
                                       message: "name max 8".localized,
                                       preferredStyle: .alert)
         let okAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
-            guard let name = alert.textFields?.first?.text,
+            guard let name = alert.textFields?.first?.text?.trimmingCharacters(in: .whitespacesAndNewlines),
                   !name.isEmpty else { return }
             self?.updateUsername(name)
         }


### PR DESCRIPTION
## 관련 issue
Close #320 
Close #321 

## 작업 내용
- [x] 챌린지를 생성하거나 수정할 때 공백만 있는 경우 챌린지가 생성되거나 수정된다.
- [x] 닉네임이 수정될 때 공백만 있는 경우 닉네임이 변경된다.

## 기타 사항
- 챌린지 생성

https://user-images.githubusercontent.com/83990431/143673558-c140720b-abf8-4bf3-af17-c506235c1d8c.mov



- 마이 페이지에서 닉네임이 없을 때나 공백만 있을 때 아예 alert 확인 버튼이 안눌리도록 변경하고 싶었는데, 너무 구조 변경이 되야 하는 것 같아서 일단 기존과 같이 작동(=수정 전 닉네임이 보이게함. )되도록 했습니다  

https://user-images.githubusercontent.com/83990431/143673549-e9c9fd2c-8a05-449e-84d3-559bc4aa5c40.mov
