### PR TITLE
[추가 화면, 인증 화면] 카메라 권한 없을 경우 Alert 띄우도록 구현

### DIFF
--- a/Routinus/Routinus/Resources/en.lproj/Localizable.strings
+++ b/Routinus/Routinus/Resources/en.lproj/Localizable.strings
@@ -102,6 +102,9 @@
 "challenge created" = "Challenge has been created.";
 "challenge edited" = "Challenge has been edited.";
 "category" = "Category";
+"simulator is not allowed" = "The camera is not available in the simulator.";
+"no camera permission" = "No camera permission";
+"go to settings" = "Go to settings";
 
 // myPage
 "theme setting" = "Theme setting";

--- a/Routinus/Routinus/Resources/ko.lproj/Localizable.strings
+++ b/Routinus/Routinus/Resources/ko.lproj/Localizable.strings
@@ -101,6 +101,9 @@
 "challenge created" = "챌린지가 생성되었습니다.";
 "challenge edited" = "챌린지가 수정되었습니다.";
 "category" = "카테고리";
+"simulator is not allowed" = "시뮬레이터에서는 카메라를 이용할 수 없습니다.";
+"no camera permission" = "카메라 권한이 없습니다. 설정에서 권한을 부여해주세요.";
+"go to settings" = "설정으로 이동";
 
 // myPage
 "theme setting" = "테마 설정";


### PR DESCRIPTION
## 관련 issue

close #334 

## 작업 내용

- [x] 카메라 권한 없을 경우 Alert 띄우도록 구현
- [x] '설정으로 이동' 버튼 클릭할 경우 Routinus 앱 설정화면으로 이동됨
